### PR TITLE
fix(gateway): extensible node roles + contract/roadmap alignment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 This document captures the gateway architecture, convergence requirements with the web repo, and the current roadmap.
 
+Roadmap brief companion: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
 ## Purpose
 The gateway is a native dependency that enables browser clients to bootstrap discovery, bridge into swarm transport, and consume DHT-backed primitives. It is not a parallel product surface.
 
@@ -13,6 +15,7 @@ Required convergence points:
 - Signed NIP-01 events
 - Discovery record schema (`kind=30078`, `t=swarm_discovery`, `type=device`)
 - Zone presence envelope (`kind=1`, `t=constitute`, `z=<zone>`, `type=zone_presence`)
+- Shared role vocabulary (`relay|gateway|browser|native`)
 
 ## Core Responsibilities
 1. Discovery bootstrap via Nostr relays
@@ -38,11 +41,11 @@ Key storage:
 ## Discovery and Presence Contracts
 ### Swarm Discovery Record
 - `kind`: `30078`
-- Tags: `['t','swarm_discovery']`, `['type','device']`
+- Tags: `['t','swarm_discovery']`, `['type','device']`, `['role','<role>']`
 - Content fields include:
   - `devicePk`, optional `identityId`, optional `deviceLabel`
   - `updatedAt`, `expiresAt`
-  - `role` (`gateway`)
+  - `role` (`relay|gateway|browser|native`; runtime defaults to `gateway` but is configurable)
   - `relays`
   - `serviceVersion`
 
@@ -110,6 +113,11 @@ Planned hardening:
 - Stronger host config update verification path
 
 ## Roadmap
+Execution order:
+1. Finish gateway contract freeze and parity gaps in this repository.
+2. Converge web implementation against frozen contracts.
+3. Build service-layer repos (starting with `constitute-nvr`) on top of the converged base.
+
 ### Phase 0: Bootstrap Parity
 - [x] Nostr keypair generation and signed events
 - [x] Zone presence and discovery schema alignment
@@ -141,8 +149,8 @@ Planned hardening:
 ## Documentation Surface
 - `README.md`
 - `docs/PROTOCOL.md`
+- `docs/ROADMAP.md`
 - `docs/OPERATIONS.md`
 - `docs/DEVELOPMENT.md`
 - `docs/FCOS.md`
 - `infra/fcos/README.md`
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Constitute Gateway
 
-Native gateway service for Constitute. This repository provides the native layer that browser clients depend on for discovery bootstrap, relay bridging, and swarm-facing transport primitives.
+Native gateway service for Constitute. This repository provides the native dependency layer that browser clients and native services depend on for discovery bootstrap, relay bridging, and swarm-facing transport primitives.
 
 ## Scope
 - Nostr-based discovery bootstrap and zone presence publication
@@ -11,13 +11,18 @@ Native gateway service for Constitute. This repository provides the native layer
 Out of scope:
 - Web UI and UX
 - Community policy UX
-- Higher-layer application crypto semantics
+- Service-specific application logic (for example NVR ingest/retention)
 
 ## Status
-- Discovery and zone presence contracts: implemented
-- Gateway record query and DHT put/get bridge: implemented
-- UDP forwarding fanout and hop bounds: implemented
-- FCOS provisioning scaffolding: implemented
+Implemented:
+- Discovery and zone presence contracts
+- Gateway record query and DHT put/get bridge
+- UDP forwarding fanout and hop bounds
+- FCOS provisioning scaffolding
+
+In progress:
+- Transport hardening for difficult NAT topologies
+- Web parity for full convergence on identity/device resolution behavior
 
 ## Opinionated Release Deploy (One-Liners)
 ### Linux (install/update, production update timer, baseline host hardening)
@@ -35,7 +40,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "iwr https://raw.githubus
 - FCOS operators: [`docs/FCOS.md`](docs/FCOS.md)
 - Contributors: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
 - Protocol contracts: [`docs/PROTOCOL.md`](docs/PROTOCOL.md)
-- Architecture and roadmap: [`ARCHITECTURE.md`](ARCHITECTURE.md)
+- Project roadmap brief: [`docs/ROADMAP.md`](docs/ROADMAP.md)
+- Architecture and detailed roadmap: [`ARCHITECTURE.md`](ARCHITECTURE.md)
 
 ## Runner Entrypoints
 - Linux/FCOS: `./scripts/run.sh`
@@ -49,4 +55,3 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "iwr https://raw.githubus
 
 ## Contributing
 Contribution standards and commit conventions are documented in [`CONTRIBUTING.md`](CONTRIBUTING.md).
-

--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,5 @@
 {
+  "node_role": "gateway",
   "bind": "0.0.0.0:4040",
   "data_dir": "./data",
   "nostr_relays": [

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,6 +5,12 @@
 - `cargo` for build and test
 - PowerShell and Bash scripts under `scripts/`
 
+## Source of Truth Order
+When making protocol/runtime changes, treat documents in this order:
+1. `docs/PROTOCOL.md` (wire contract)
+2. `ARCHITECTURE.md` and `docs/ROADMAP.md` (phase intent and sequencing)
+3. implementation + tests
+
 ## Local Build
 ### Direct cargo
 ```bash
@@ -22,6 +28,7 @@ Build actions are grouped under the `Build` menu in both runners.
 ```bash
 cargo test --features platform-windows -j 1
 cargo test --features platform-linux -j 1
+cargo test
 ```
 
 ## Formatting
@@ -59,6 +66,12 @@ Optional PowerShell parser check:
 ```powershell
 [void][System.Management.Automation.Language.Parser]::ParseFile('.\scripts\run.ps1',[ref]$null,[ref]$null)
 ```
+
+## Contract-First Change Pattern
+1. Propose the contract change in `docs/PROTOCOL.md`.
+2. Add tests for accept/reject behavior.
+3. Implement runtime change.
+4. Update `ARCHITECTURE.md`, `docs/ROADMAP.md`, and ops docs if behavior or deployment changed.
 
 ## Change Expectations
 - Add or update tests when behavior changes.

--- a/docs/FCOS.md
+++ b/docs/FCOS.md
@@ -2,6 +2,8 @@
 
 This document defines the Fedora CoreOS deployment path for `constitute-gateway`.
 
+Roadmap context: [`docs/ROADMAP.md`](ROADMAP.md).
+
 ## Goals
 - Immutable host baseline
 - Network-gated first boot

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -81,9 +81,21 @@ Baseline guidance:
 - Keep default logging minimal.
 - Apply CPU quotas and restart policies for stability.
 
+## Role Configuration
+- `node_role` is the primary runtime role config key (default: `gateway`).
+- Legacy `node_type` is accepted for backward compatibility.
+- Role values are normalized to lowercase and must be ASCII `[a-z0-9_-]`.
+
 ## Verification Checklist
 - Service is installed and active (or intentionally stopped).
 - Gateway self-test passes relay publication/check.
 - Expected peer discovery occurs for joined zones.
 - Default logs do not expose sensitive values.
 - Update timer health is valid when enabled.
+
+## Convergence Readiness Checks
+Before switching primary work to web convergence:
+- Gateway contract is current in [`docs/PROTOCOL.md`](PROTOCOL.md).
+- Runtime behavior matches `ARCHITECTURE.md` phase status.
+- CI passes on both Linux and Windows build/test lanes.
+- Open gateway P0/P1 blockers are explicitly tracked.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,95 +1,173 @@
-# Protocol Notes
+# Gateway Protocol Contract
 
-## Compatibility Rule
-Protocol changes in this repo must remain convergent with the web repo contracts (`constitute`).
+This document defines the protocol contract for `constitute-gateway` and the expected convergence surface with the web repository.
+
+## Contract Status
+- Status: `active`
+- Scope: gateway runtime, web<->gateway app channel, gateway<->gateway transport
+- Compatibility rule: additive changes only unless a version gate is introduced and implemented on both gateway and web
+
+## Canonical Terms
+- `devicePk`: Nostr public key that identifies a runtime node
+- `identityId`: logical identity identifier
+- `zone`: discovery/replication partition key
+- `record`: signed Nostr event carrying `identity`, `device`, or `dht` payload
+
+## Node Roles
+The role vocabulary is shared across discovery and presence payloads:
+- `relay`
+- `gateway`
+- `browser`
+- `native`
+
+Current runtime behavior:
+- Gateway defaults to `role = gateway` and may publish another configured role.
+- Consumers must treat unknown role values as non-fatal.
 
 ## Discovery Plane
 
-### Device Discovery Record
-- Nostr `kind`: `30078`
+### 1) Swarm Discovery Record
+Signed Nostr event:
+- `kind = 30078`
 - Required tags:
   - `['t', 'swarm_discovery']`
   - `['type', 'device']`
-- Content fields:
-  - `devicePk`
-  - `identityId` (optional)
-  - `deviceLabel` (optional)
-  - `updatedAt`
-  - `expiresAt`
-  - `role`
-  - `relays`
-  - `serviceVersion`
+  - `['role', '<role>']`
 
-### Zone Presence
-- Nostr `kind`: `1`
+Content fields:
+- `devicePk` (required)
+- `identityId` (optional)
+- `deviceLabel` (optional)
+- `updatedAt` (required, ms)
+- `expiresAt` (required, ms)
+- `role` (required)
+- `relays` (array, optional)
+- `serviceVersion` (required)
+
+### 2) Zone Presence
+Signed Nostr event:
+- `kind = 1`
 - Required tags:
   - `['t', 'constitute']`
   - `['z', '<zone_key>']`
-- Content fields:
-  - `type = zone_presence`
-  - `zone`
-  - `devicePk`
-  - `swarm`
-  - `role`
-  - `relays`
-  - `serviceVersion`
-  - `metrics`
-  - `ts`
-  - `ttl`
 
-## App Channel Queries
-Incoming event type:
+Content fields:
+- `type = zone_presence`
+- `zone` (required)
+- `devicePk` (required)
+- `swarm` (required; may be empty until endpoint resolves)
+- `role` (required)
+- `relays` (array, optional)
+- `serviceVersion` (required)
+- `metrics` (optional)
+- `ts` (required, ms)
+- `ttl` (required, seconds)
+
+### Metrics Payload (when present)
+- `clients`
+- `cpuPct`
+- `memPct`
+- `memUsedMb`
+- `memTotalMb`
+- `loadPct`
+- `ts`
+
+## Web <-> Gateway App Channel
+App-channel events are Nostr events tagged with `['t', 'constitute']`.
+
+### Request: Record Lookup
+Incoming types accepted by gateway:
 - `swarm_record_request`
+- `swarm_discovery_request` (compat alias)
 
-Optional fields:
-- `requestId`
-- `timeoutMs`
-- `zone`
-- `identityId`
-- `devicePk`
-- `want: [identity, device]`
+Fields:
+- `requestId` (optional)
+- `timeoutMs` (optional)
+- `zone` (optional)
+- `identityId` (optional)
+- `devicePk` (optional)
+- `want` (optional array: `identity`, `device`, `dht`; defaults depend on request type)
 
-## DHT Events
-### Read
-Incoming type:
-- `swarm_dht_get`
-
-Required fields:
-- `scope` or `dhtScope`
-- `key` or `dhtKey`
-
-Optional fields:
-- `zone`
-- `requestId`
-- `timeoutMs`
-
-### Write
-Incoming type:
-- `swarm_dht_put`
-
-Required fields:
-- `scope` or `dhtScope`
-- `key` or `dhtKey`
-- `value`
-
-Optional fields:
-- `zone`
-- `updatedAt`
-- `expiresAt`
-- `requestId`
-
-## Outgoing Gateway Events
+Gateway responses:
 - `swarm_identity_record`
 - `swarm_device_record`
 - `swarm_dht_record`
-- `swarm_record_response` with status:
-  - `pending`
-  - `complete`
-  - `timeout`
+- `swarm_record_response` (`pending`, `complete`, `timeout`)
 
-## UDP Transport Expectations
-- Zone-scoped gossip/propagation
-- Targeted request by `identityId`, `devicePk`, or (`dhtScope`, `dhtKey`)
-- Fanout bounded by `udp_request_fanout`
-- Forwarding bounded by `udp_request_max_hops`
-- Message version validated via `UDP_PROTOCOL_VERSION`
+### Request: DHT Read
+Incoming type:
+- `swarm_dht_get`
+
+Fields:
+- Required: `scope` or `dhtScope`, `key` or `dhtKey`
+- Optional: `zone`, `requestId`, `timeoutMs`
+
+### Request: DHT Write
+Incoming type:
+- `swarm_dht_put`
+
+Fields:
+- Required: `scope` or `dhtScope`, `key` or `dhtKey`, `value`
+- Optional: `zone`, `updatedAt`, `expiresAt`, `requestId`
+
+## Gateway <-> Gateway UDP Transport
+
+### Message Envelope
+- Transport: UDP
+- Version field: `v`
+- Current version: `1`
+- Unknown versions: drop silently
+
+### Message Kinds
+- `hello`
+- `ack`
+- `record`
+- `recordrequest`
+
+### Zone-Scoped Rules
+- Gossip and record propagation are zone-scoped.
+- Requests may be targeted by:
+  - `identityId`
+  - `devicePk`
+  - `dhtScope` + `dhtKey`
+- Forwarding bounds:
+  - max peers per request: `udp_request_fanout`
+  - max forwarding depth: `udp_request_max_hops`
+
+## Validation and Security Invariants
+
+### Relay Ingest (WS/WSS)
+- Reject non-JSON or non-Nostr envelopes.
+- Verify NIP-01 signature before fanout.
+- Enforce created-at replay window and skew bounds.
+- If payload has `ts`, enforce timestamp window.
+- If payload has `ts` + `ttl`, enforce expiration.
+- Deduplicate by event id before broadcast.
+- Enforce per-client frame size and rate limit.
+
+### Store Validation
+Record acceptance requires:
+- valid signature
+- valid tag contract (`kind=30078`, `t=swarm_discovery`, `type=<record>`)
+- non-expired `expiresAt` when provided
+- record-specific checks:
+  - `identity`: `identityId` present and publisher included in `devicePks`
+  - `device`: `devicePk` present and equals event `pubkey`
+  - `dht`: `scope`, `key`, and `value` present; optional `authorPk` must match event `pubkey`
+
+### Replay/Loop Boundaries
+- Event-id replay cache is enforced for inbound processing.
+- Rebroadcast excludes events authored by self.
+- Allowed relay fanout classes are constrained to `t=constitute` or `t=swarm_discovery`.
+
+## Convergence Targets (Gateway -> Web)
+The following are intended to be completed before broad web convergence work:
+- exact signaling envelope parity for swarm signaling messages
+- parity for identity/device resolution behavior and fallback order
+- parity for zone membership durability and sync semantics
+- shared test vectors for accepted/rejected envelopes
+
+## Versioning Policy
+- Keep this contract backward-compatible whenever possible.
+- For breaking changes, add an explicit version marker and dual-accept period.
+- Remove legacy aliases only after web and gateway both pass compatibility tests.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,11 +7,14 @@ This folder is the primary documentation surface for `constitute-gateway`.
 - FCOS operators: [`docs/FCOS.md`](FCOS.md)
 - Contributors: [`docs/DEVELOPMENT.md`](DEVELOPMENT.md)
 - Protocol implementers: [`docs/PROTOCOL.md`](PROTOCOL.md)
-- Architecture and roadmap: [`ARCHITECTURE.md`](../ARCHITECTURE.md)
+- Program roadmap brief: [`docs/ROADMAP.md`](ROADMAP.md)
+- Architecture and long-form roadmap: [`ARCHITECTURE.md`](../ARCHITECTURE.md)
 
 ## Document Roles
 - [`docs/PROTOCOL.md`](PROTOCOL.md)
-  - Discovery tags, event envelopes, DHT read/write semantics, and compatibility constraints.
+  - Wire contracts, validation rules, app-channel and UDP message semantics.
+- [`docs/ROADMAP.md`](ROADMAP.md)
+  - Project-wide sequencing: gateway -> web convergence -> service layer (`constitute-nvr`).
 - [`docs/OPERATIONS.md`](OPERATIONS.md)
   - Runtime operations, install/update flows, hardening, and verification checks.
 - [`docs/FCOS.md`](FCOS.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,66 @@
+# Project Roadmap Brief
+
+This brief captures execution order across `constitute-gateway`, `constitute` (web), and `constitute-nvr`.
+
+## Delivery Strategy
+1. Stabilize and freeze gateway contracts.
+2. Converge web implementation against those contracts.
+3. Add higher-level services (starting with `constitute-nvr`) on top of the converged base.
+
+Rationale:
+- Gateway is the transport/control dependency for web and native service clients.
+- Contract stability reduces thrash during web convergence.
+- Service-layer work (NVR and similar) should consume stable primitives, not redefine them.
+
+## Current Snapshot
+- Gateway: core discovery, app-channel bridge, and zone-scoped UDP/DHT path implemented.
+- Web convergence: partial; parity work remains.
+- NVR: not started in this repository (future sibling service repository).
+
+## Phase Plan
+
+### Phase A: Gateway Contract Freeze
+Objectives:
+- finalize protocol contracts in `docs/PROTOCOL.md`
+- close remaining transport/runtime gaps needed for parity
+- keep security invariants test-backed
+
+Exit criteria:
+- contract doc reviewed and stable
+- gateway tests green in CI for Linux and Windows
+- no unresolved P0 parity blockers in gateway architecture roadmap
+
+### Phase B: Web Convergence
+Objectives:
+- align `constitute` web event envelopes and request/response flows
+- match identity/device lookup behavior with gateway
+- validate zone durability and sync behavior end-to-end
+
+Exit criteria:
+- cross-repo compatibility test plan passes
+- no schema drift between web and gateway contracts
+- web fallback path validated: relay <-> gateway path behaves deterministically
+
+### Phase C: Service Layer (NVR First)
+Objectives:
+- implement `constitute-nvr` as a separate native service/client
+- publish service capability and endpoint metadata via contract-compliant records
+- keep gateway focused on transport/control plane, not NVR app internals
+
+Exit criteria:
+- NVR service advertises and resolves over converged gateway/web contracts
+- NVR ingestion/retention/auth flows are isolated to service layer
+- operational runbook includes co-hosted and split-host deployment models
+
+## Known Risks and Controls
+- Risk: gateway/web contract drift during active iteration.
+  - Control: protocol-first changes and compatibility test vectors.
+- Risk: transport changes break app-channel assumptions.
+  - Control: end-to-end contract tests before web merge.
+- Risk: service scope bleeding into gateway core.
+  - Control: strict boundary; services consume gateway APIs/events.
+
+## Near-Term Priority Order
+1. finish gateway parity gaps called out in `ARCHITECTURE.md`
+2. execute web convergence pass
+3. start `constitute-nvr` scaffolding and capability advertisements


### PR DESCRIPTION
## Summary
This PR makes gateway node roles runtime-extensible while preserving backward compatibility, and updates the contract/roadmap docs for the gateway-first convergence plan.

## What Changed
- Added `node_role` as the primary runtime role config key (default: `gateway`).
- Kept legacy `node_type` support for backward compatibility.
- Normalized role values to lowercase ASCII `[a-z0-9_-]`.
- Switched role publication paths to use resolved runtime role:
  - discovery record role tags/content
  - self-test event type tag
- Added unit tests for role resolution behavior.

## Documentation Updates
- Expanded protocol contract in `docs/PROTOCOL.md` with validation invariants and convergence targets.
- Added project sequencing brief in `docs/ROADMAP.md`.
- Updated `README.md`, `ARCHITECTURE.md`, and docs index/ops/dev/FCOS references for the current direction.

## Validation
- `cargo test`
- `cargo test --features platform-windows -j 1`
- `cargo test --features platform-linux -j 1`

Fixes #4
Related to #1