### PR TITLE
docs(roadmap): finalize iteration-1 handoff guidance

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,3 +64,21 @@ Exit criteria:
 1. finish gateway parity gaps called out in `ARCHITECTURE.md`
 2. execute web convergence pass
 3. start `constitute-nvr` scaffolding and capability advertisements
+
+## Iteration-1 Handoff Status
+Gateway iteration-1 is considered handoff-ready for web catch-up when the following are true:
+- contract docs are frozen for current behavior (`docs/PROTOCOL.md`)
+- CI is green on Linux and Windows build/test lanes
+- gateway app-channel flows are verified by tests (`swarm_record_request`, `swarm_dht_put/get`)
+- role publication model is extensible and backward compatible
+
+Current disposition:
+- Ready to start web catch-up on `constitute` issue #2.
+- Longer-running operator host validation (real deployment environment soak checks) is tracked as a separate follow-up and does not block web catch-up.
+
+## Estimation Guidance
+To account for offline human intervals and review latency:
+- apply a 1.5x to 2.0x calendar buffer to implementation estimates
+- split work into issue-sized slices that each close within 1-3 focused sessions
+- prefer milestone-level target dates over single-day deadlines for integration-heavy phases
+


### PR DESCRIPTION
## Summary
Records gateway iteration-1 handoff readiness criteria and estimate policy adjustments in the roadmap brief.

## Changes
- Adds an iteration-1 handoff status section in `docs/ROADMAP.md`.
- Explicitly captures that web catch-up can begin once gateway contract/CI gates are met.
- Adds estimation guidance with offline/review latency buffers (1.5x-2.0x calendar buffer).

## Why
This supports the final gateway sprint tracking issue (#6) and helps keep planning realistic when work cadence includes offline intervals.

Related: #6