### PR TITLE
fix: prevent rustls CryptoProvider panic on wss startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sysinfo = "0.29"
 bytes = "1"
 quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring"] }
 rcgen = "0.13"
-rustls = "0.23"
+rustls = { version = "0.23", features = ["ring"] }
 eframe = { version = "0.29", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary\n- enable rustls ing provider feature in Cargo.toml\n- prevents runtime panic: Could not automatically determine the process-level CryptoProvider\n\n## Validation\n- cargo test --features platform-linux -j 1\n- cargo test --features platform-windows -j 1\n\nCloses #22