### PR TITLE
docs: simplify install/onboarding guidance and operator reference flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Constitute Gateway
 
-Native gateway service for Constitute. This repository provides the native dependency layer that browser clients and native services depend on for discovery bootstrap, relay bridging, and swarm-facing transport primitives.
+Native gateway service for Constitute. This repository provides the native dependency layer that browser clients and native services use for discovery bootstrap, relay bridging, and swarm-facing transport primitives.
 
 ## Scope
 - Nostr-based discovery bootstrap and zone presence publication
@@ -25,17 +25,16 @@ In progress:
 - Transport hardening and operational tuning for difficult NAT topologies
 - Web parity for full convergence on identity/device resolution behavior
 
-## Install Paths
-Recommended (owner workflow):
+## Installation
+Web workflow:
 - In `constitute` web, open `Settings > Appliances`
 - Use `Download Installer Utility`
-- Run the generated operator command shown in UI
+- Run the generated operator command
 
-CLI and source-build install flows:
-- README intentionally keeps install snippets minimal; complete CLI/source/advanced flows live in `docs/OPERATOR.md`.
+CLI and source-build workflow:
 - See [`docs/OPERATOR.md`](docs/OPERATOR.md)
 
-Operations and lifecycle (status/start/stop/hardening):
+Runtime operations:
 - See [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
 
 ## Operator Artifacts
@@ -45,10 +44,10 @@ Release assets include:
 
 Operator scope is service install/update only (no media/image build path).
 
-## Start Here
-- Operator install and CLI reference: [`docs/OPERATOR.md`](docs/OPERATOR.md)
-- Runtime operations: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
-- Contributors: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
+## Documentation
+- Operator install/update and CLI reference: [`docs/OPERATOR.md`](docs/OPERATOR.md)
+- Runtime operations and hardening: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
+- Development workflow: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
 - Protocol contracts: [`docs/PROTOCOL.md`](docs/PROTOCOL.md)
 - Project roadmap brief: [`docs/ROADMAP.md`](docs/ROADMAP.md)
 - Architecture and detailed roadmap: [`ARCHITECTURE.md`](ARCHITECTURE.md)

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -1,22 +1,19 @@
 # Operator Guide
 
-This document is the install/update reference for `constitute-gateway`.
+This document is the install and update reference for `constitute-gateway`.
 
-## Preferred Flow (Web-Driven)
-1. In `constitute` web: open `Settings > Appliances`.
-2. Click `Download Installer Utility`.
-3. Run the generated operator command shown in the UI.
-
-Notes:
-- The command passes `--pair-identity`.
-- On first install (when gateway is not already paired), installer scripts generate a one-time pairing code and print it.
-- Claim that code in `Settings > Pairing > Add Device` and approve.
-
-## Release Utility Assets
+## Release Artifacts
 - Windows: `constitute-operator-windows.zip`
 - Linux: `constitute-operator-linux-amd64.tar.gz`
 
-## CLI Quick Start
+## Web-Driven Install
+1. In `constitute` web, open `Settings > Appliances`.
+2. Click `Download Installer Utility`.
+3. Run the generated command from the operator host.
+
+The generated command passes `--pair-identity` so the installer can prepare pairing material when needed.
+
+## CLI Quick Start (Release Utility)
 
 ### Windows
 ```powershell
@@ -30,24 +27,30 @@ Notes:
 
 ## Build From Source
 
-### Windows (PowerShell)
+### Windows
 ```powershell
-git clone https://github.com/Aux0x7F/constitute-gateway.git; cd constitute-gateway; cargo build --release --features platform-windows --bin constitute-operator; .\target\release\constitute-operator.exe --pair-identity "<IDENTITY_LABEL>" windows-service
+git clone https://github.com/Aux0x7F/constitute-gateway.git
+cd constitute-gateway
+cargo build --release --features platform-windows --bin constitute-operator
+.\target\release\constitute-operator.exe --pair-identity "<IDENTITY_LABEL>" windows-service
 ```
 
-### Linux (Bash)
+### Linux
 ```bash
-git clone https://github.com/Aux0x7F/constitute-gateway.git && cd constitute-gateway && cargo build --release --features platform-linux --bin constitute-operator && ./target/release/constitute-operator --pair-identity "<IDENTITY_LABEL>" linux-service
+git clone https://github.com/Aux0x7F/constitute-gateway.git
+cd constitute-gateway
+cargo build --release --features platform-linux --bin constitute-operator
+./target/release/constitute-operator --pair-identity "<IDENTITY_LABEL>" linux-service
 ```
 
-## Pairing Generation Rules
-Pair code generation only occurs when all of the following are true:
+## Pairing Behavior
+Pairing code generation occurs only when all conditions are true:
 - `--pair-identity` is provided.
-- Installer is run with pair generation enabled (operator does this automatically).
-- Local gateway is not already paired (`identity_id` is empty in config).
+- Installer pair generation is enabled (handled by operator utility).
+- Gateway is not already paired (`identity_id` is empty).
 - Existing pairing material is missing or invalid for the target identity.
 
-Generation does not occur on normal updates for already-paired gateways.
+On generation, the installer prints the one-time code. Claim it in `Settings > Pairing > Add Device`.
 
 ## Advanced CLI Options
 Global options:
@@ -63,10 +66,10 @@ Subcommands:
 - `windows-service`
 - `linux-service`
 
-## Script-Level Alternatives
-You can call installer scripts directly, but operator is the canonical interface:
-- Linux release script: `scripts/linux/install-latest.sh`
-- Windows release script: `scripts/windows/install-latest.ps1`
+## Direct Script Usage
+Operator utility is the primary interface. Script-level entry points are available for automation:
+- Linux release installer: `scripts/linux/install-latest.sh`
+- Windows release installer: `scripts/windows/install-latest.ps1`
 - Linux local-dev bootstrap: `scripts/linux/install-dev-local.sh`
 
 ## Related Docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ This folder is the primary documentation surface for `constitute-gateway`.
 
 ## Document Roles
 - [`docs/OPERATOR.md`](OPERATOR.md)
-  - Installer utility usage, CLI quick start, source-build one-liners, and pairing behavior.
+  - Installer utility usage, CLI quick start, source-build workflow, and pairing behavior.
 - [`docs/OPERATIONS.md`](OPERATIONS.md)
   - Runtime operations, service lifecycle, hardening, and verification checks.
 - [`docs/PROTOCOL.md`](PROTOCOL.md)


### PR DESCRIPTION
## Summary
- remove recommendation/meta phrasing from gateway install docs
- keep README concise and route detail to docs/OPERATOR.md
- replace source build one-liners with explicit step-by-step commands
- align docs index language with the updated operator guide structure
