### PR TITLE
fix(pairing): persist approved gateway identity to keystore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,10 +1022,12 @@ dependencies = [
 name = "constitute-gateway"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "anyhow",
  "argon2",
  "base64",
  "bytes",
+ "cbc",
  "chacha20poly1305",
  "clap",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ anyhow = "1"
 argon2 = "0.5"
 base64 = "0.22"
 chacha20poly1305 = "0.10"
+aes = "0.8"
+cbc = { version = "0.1", features = ["alloc"] }
 clap = { version = "4", features = ["derive"] }
 keyring = "2"
 rand = "0.8"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -50,6 +50,7 @@ Supported by `scripts/linux/install-latest.sh`:
 - Installer generates one-time pairing code only when pairing is pending and identity pairing is enabled.
 - Generated code is printed to terminal and claimed from owner web UI (`Settings > Pairing > Add Device`).
 - Updates should not regenerate pairing material for already-paired devices.
+- On `pair_approve`, gateway persists the resolved `identity_id` in encrypted keystore state and exits once so the paired runtime reloads with the durable identity context.
 
 ## Gateway Zone Sync Contract
 - Owner web clients may submit `gateway_zone_sync_request` with identity zones plus optional gateway-extra zones.

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -51,6 +51,7 @@ Pairing code generation occurs only when all conditions are true:
 - Existing pairing material is missing or invalid for the target identity.
 
 On generation, the installer prints the one-time code. Claim it in `Settings > Pairing > Add Device`.
+After approval, the gateway persists the resolved `identity_id` into encrypted keystore state and performs one controlled restart so the paired runtime state is applied cleanly.
 
 ## Advanced CLI Options
 Global options:

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -154,6 +154,39 @@ pub fn update_zones(data_dir: &str, zones: Vec<ZoneEntry>) -> Result<()> {
     Ok(())
 }
 
+pub fn update_identity(
+    data_dir: &str,
+    identity_id: &str,
+    device_label: Option<&str>,
+) -> Result<()> {
+    let dir = PathBuf::from(data_dir);
+    std::fs::create_dir_all(&dir)?;
+    let store_path = dir.join(STORE_FILE_NAME);
+    if !store_path.exists() {
+        return Err(anyhow!("keystore not initialized"));
+    }
+
+    let raw = std::fs::read_to_string(&store_path)?;
+    let enc: EncryptedStore = serde_json::from_str(&raw)?;
+
+    let (key_source, _) = select_key_source(&dir)?;
+    let key = key_source.derive_key(&enc)?;
+    let mut payload = decrypt_payload(&enc, &key)?;
+    payload.identity_id = identity_id.trim().to_string();
+
+    if let Some(label) = device_label {
+        let trimmed = label.trim();
+        if !trimmed.is_empty() {
+            payload.device_label = trimmed.to_string();
+        }
+    }
+
+    let next = encrypt_payload(&payload, &key_source)?;
+    let out = serde_json::to_string_pretty(&next)?;
+    std::fs::write(store_path, out)?;
+    Ok(())
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct SecureSeed {
     pub nostr_pubkey: String,
@@ -325,10 +358,58 @@ fn decrypt_payload(enc: &EncryptedStore, key: &[u8]) -> Result<StorePayload> {
 #[cfg(test)]
 mod tests {
     use base64::Engine as _;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        decrypt_payload, derive_key_from_pass, encrypt_payload, KeySource, StorePayload, ZoneEntry,
+        decrypt_payload, derive_key_from_pass, encrypt_payload, load_or_init, update_identity,
+        KeySource, SecureSeed, StorePayload, ZoneEntry,
     };
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvRestore {
+        no_keyring: Option<String>,
+        passphrase: Option<String>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.no_keyring.as_deref() {
+                Some(v) => std::env::set_var("CONSTITUTE_GATEWAY_NO_KEYRING", v),
+                None => std::env::remove_var("CONSTITUTE_GATEWAY_NO_KEYRING"),
+            }
+            match self.passphrase.as_deref() {
+                Some(v) => std::env::set_var("CONSTITUTE_GATEWAY_PASSPHRASE", v),
+                None => std::env::remove_var("CONSTITUTE_GATEWAY_PASSPHRASE"),
+            }
+        }
+    }
+
+    fn force_passphrase_env(passphrase: &str) -> EnvRestore {
+        let restore = EnvRestore {
+            no_keyring: std::env::var("CONSTITUTE_GATEWAY_NO_KEYRING").ok(),
+            passphrase: std::env::var("CONSTITUTE_GATEWAY_PASSPHRASE").ok(),
+        };
+        std::env::set_var("CONSTITUTE_GATEWAY_NO_KEYRING", "1");
+        std::env::set_var("CONSTITUTE_GATEWAY_PASSPHRASE", passphrase);
+        restore
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "constitute-gateway-{name}-{}-{stamp}",
+            std::process::id()
+        ))
+    }
 
     #[test]
     fn encrypt_decrypt_roundtrip() {
@@ -355,5 +436,36 @@ mod tests {
         assert_eq!(out.identity_id, "id");
         assert_eq!(out.device_label, "label");
         assert_eq!(out.zones.len(), 1);
+    }
+
+    #[test]
+    fn update_identity_roundtrip_persists_identity_and_label() {
+        let _guard = env_lock().lock().expect("env lock");
+        let _restore = force_passphrase_env("test-pass-update-identity");
+        let data_dir = unique_temp_dir("identity");
+
+        let seed = SecureSeed {
+            device_label: "Gateway Before Pair".to_string(),
+            ..SecureSeed::default()
+        };
+
+        let (initial, _) = load_or_init(data_dir.to_str().expect("dir str"), seed).expect("init");
+        let initial_pk = initial.nostr_pubkey.clone();
+
+        update_identity(
+            data_dir.to_str().expect("dir str"),
+            "id-paired-42",
+            Some("Gateway After Pair"),
+        )
+        .expect("update identity");
+
+        let (updated, _) = load_or_init(data_dir.to_str().expect("dir str"), SecureSeed::default())
+            .expect("reload");
+
+        assert_eq!(updated.nostr_pubkey, initial_pk);
+        assert_eq!(updated.identity_id, "id-paired-42");
+        assert_eq!(updated.device_label, "Gateway After Pair");
+
+        let _ = std::fs::remove_dir_all(&data_dir);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ struct ZoneConfig {
     name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 struct Config {
     #[serde(default)]
     node_id: String,
@@ -305,6 +305,36 @@ struct GatewayZoneSyncStatusPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<String>,
     ts: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PairApprovePayload {
+    #[serde(default)]
+    identity: String,
+    #[serde(default)]
+    code: String,
+    #[serde(default, rename = "toPk")]
+    to_pk: String,
+    #[serde(default, rename = "fromPk")]
+    from_pk: String,
+    #[serde(default, rename = "encryptedRoomKey")]
+    encrypted_room_key: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PairApproveSecret {
+    #[serde(default, rename = "identityId")]
+    identity_id: String,
+    #[serde(default)]
+    devices: Vec<PairApproveDeviceEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PairApproveDeviceEntry {
+    #[serde(default)]
+    pk: String,
+    #[serde(default)]
+    label: String,
 }
 
 fn default_bind() -> String {
@@ -585,12 +615,13 @@ async fn main() -> Result<()> {
 
     // Persist only non-sensitive operational config; keystore owns secret material.
     if dirty {
-        // Do not persist secure fields into config.json for safety.
-        cfg.nostr_sk_hex.clear();
-        cfg.identity_id.clear();
-        cfg.device_label.clear();
-        cfg.zones.clear();
-        let _ = save_config(&config_path, &cfg);
+        // Do not mutate in-memory runtime config when sanitizing persisted config.json.
+        let mut persisted = cfg.clone();
+        persisted.nostr_sk_hex.clear();
+        persisted.identity_id.clear();
+        persisted.device_label.clear();
+        persisted.zones.clear();
+        let _ = save_config(&config_path, &persisted);
     }
 
     if cfg.nostr_relays.is_empty() {
@@ -777,7 +808,9 @@ async fn main() -> Result<()> {
     };
 
     if !pair_identity_label.is_empty() {
-        if pair_code_hash.is_empty() {
+        if !cfg.identity_id.trim().is_empty() {
+            info!(identity_id = %cfg.identity_id, "pairing already resolved; skipping enroll request");
+        } else if pair_code_hash.is_empty() {
             warn!("pair_identity_label configured but no pair_code or pair_code_hash was provided");
         } else if cfg.nostr_pubkey.is_empty() || cfg.nostr_sk_hex.is_empty() {
             warn!("pairing enroll request skipped: nostr keypair unavailable");
@@ -790,15 +823,18 @@ async fn main() -> Result<()> {
             let pair_zones = zones.clone();
             let pair_interval = Duration::from_secs(cfg.pair_request_interval_secs.max(5));
             let pair_attempts = cfg.pair_request_attempts.max(1);
+            let pair_identity_label_for_publish = pair_identity_label.clone();
+            let pair_code_for_publish = pair_code.clone();
+            let pair_code_hash_for_publish = pair_code_hash.clone();
             tokio::spawn(async move {
                 let mut ticker = tokio::time::interval(pair_interval);
                 for attempt in 1..=pair_attempts {
                     match build_pair_request_event(
                         &pair_pk,
                         &pair_sk,
-                        &pair_identity_label,
-                        &pair_code,
-                        &pair_code_hash,
+                        &pair_identity_label_for_publish,
+                        &pair_code_for_publish,
+                        &pair_code_hash_for_publish,
                         &pair_label,
                         &pair_zones,
                     ) {
@@ -812,7 +848,7 @@ async fn main() -> Result<()> {
                             info!(
                                 attempt,
                                 attempts = pair_attempts,
-                                identity = %pair_identity_label,
+                                identity = %pair_identity_label_for_publish,
                                 "published gateway pair_request enrollment"
                             );
                         }
@@ -954,6 +990,8 @@ async fn main() -> Result<()> {
         data_dir: cfg.data_dir.clone(),
         self_sk: cfg.nostr_sk_hex.clone(),
         gateway_identity_id: cfg.identity_id.clone(),
+        pair_identity_label: pair_identity_label.clone(),
+        pair_code_hash: pair_code_hash.clone(),
         rebroadcast: cfg.relay_rebroadcast,
         relay_pool: relay_pool.clone(),
         local_relay: local_relay.clone(),
@@ -2834,6 +2872,8 @@ struct InboundContext {
     data_dir: String,
     self_sk: String,
     gateway_identity_id: String,
+    pair_identity_label: String,
+    pair_code_hash: String,
     rebroadcast: bool,
     relay_pool: relay::RelayPool,
     local_relay: Option<local_relay::LocalRelayHandle>,
@@ -3016,6 +3056,114 @@ async fn seen_or_insert(
     false
 }
 
+async fn handle_pair_approve_event(
+    ctx: &InboundContext,
+    ev: &nostr::NostrEvent,
+    payload: &Value,
+) -> bool {
+    let req: PairApprovePayload = match serde_json::from_value(payload.clone()) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    let to_pk = req.to_pk.trim();
+    if to_pk.is_empty() || to_pk != ctx.self_pk.trim() {
+        return false;
+    }
+
+    let identity_label = req.identity.trim();
+    if identity_label.is_empty() {
+        warn!("pair_approve ignored: missing identity label");
+        return false;
+    }
+
+    if !ctx.pair_identity_label.trim().is_empty()
+        && identity_label != ctx.pair_identity_label.trim()
+    {
+        warn!(identity = %identity_label, expected = %ctx.pair_identity_label, "pair_approve ignored: identity mismatch");
+        return false;
+    }
+
+    let code = req.code.trim();
+    if code.is_empty() {
+        warn!("pair_approve ignored: missing code");
+        return false;
+    }
+
+    if !ctx.pair_code_hash.trim().is_empty() {
+        let computed = util::sha256_b64url(&format!("{}|{}", identity_label, code));
+        if computed != ctx.pair_code_hash.trim() {
+            warn!("pair_approve ignored: code hash mismatch");
+            return false;
+        }
+    }
+
+    let from_pk = if req.from_pk.trim().is_empty() {
+        ev.pubkey.trim().to_string()
+    } else {
+        req.from_pk.trim().to_string()
+    };
+    if from_pk != ev.pubkey.trim() {
+        warn!("pair_approve ignored: fromPk/pubkey mismatch");
+        return false;
+    }
+
+    if req.encrypted_room_key.trim().is_empty() {
+        warn!("pair_approve ignored: missing encryptedRoomKey");
+        return false;
+    }
+
+    let decrypted = match nostr::nip04_decrypt(&ctx.self_sk, &from_pk, &req.encrypted_room_key) {
+        Ok(v) => v,
+        Err(err) => {
+            warn!(error = %err, "pair_approve decrypt failed");
+            return false;
+        }
+    };
+
+    let secret: PairApproveSecret = match serde_json::from_str(&decrypted) {
+        Ok(v) => v,
+        Err(err) => {
+            warn!(error = %err, "pair_approve payload decode failed");
+            return false;
+        }
+    };
+
+    let identity_id = secret.identity_id.trim().to_string();
+    if identity_id.is_empty() {
+        warn!("pair_approve ignored: identityId missing in decrypted payload");
+        return false;
+    }
+
+    if !ctx.gateway_identity_id.trim().is_empty() && ctx.gateway_identity_id.trim() == identity_id {
+        return false;
+    }
+
+    let self_pk = ctx.self_pk.trim();
+    let device_label = secret
+        .devices
+        .iter()
+        .find(|d| d.pk.trim() == self_pk)
+        .map(|d| d.label.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    if let Err(err) =
+        keystore::update_identity(&ctx.data_dir, &identity_id, device_label.as_deref())
+    {
+        warn!(error = %err, "pair_approve persistence failed");
+        return false;
+    }
+
+    info!(identity = %identity_label, identity_id = %identity_id, "pair_approve accepted; scheduling gateway restart to apply identity");
+
+    tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        std::process::exit(42);
+    });
+
+    true
+}
+
 // Core trust boundary for inbound events: signature validation, replay gating,
 // record indexing, and request lifecycle handling converge here.
 async fn process_inbound_event(
@@ -3142,6 +3290,12 @@ async fn process_inbound_event(
                 }
             }
         }
+        if kind == "pair_approve" {
+            if handle_pair_approve_event(&ctx, &nostr_ev, &payload).await {
+                return;
+            }
+        }
+
         if kind == "gateway_service_install_request" {
             handle_gateway_service_install_request(&ctx, &nostr_ev, &payload).await;
             return;
@@ -4123,6 +4277,8 @@ mod tests {
             seen_ttl: Duration::from_secs(600),
             seen_max: 1024,
             gateway_identity_id: "id-test".to_string(),
+            pair_identity_label: String::new(),
+            pair_code_hash: String::new(),
             remote_service_install_enabled: false,
             remote_service_install_timeout_secs: 300,
             authorized_control_device_pks: HashSet::new(),
@@ -4306,6 +4462,8 @@ mod tests {
             seen_ttl: Duration::from_secs(600),
             seen_max: 1024,
             gateway_identity_id: "id-test".to_string(),
+            pair_identity_label: String::new(),
+            pair_code_hash: String::new(),
             remote_service_install_enabled: false,
             remote_service_install_timeout_secs: 300,
             authorized_control_device_pks: HashSet::new(),
@@ -4446,6 +4604,8 @@ mod tests {
             seen_ttl: Duration::from_secs(600),
             seen_max: 1024,
             gateway_identity_id: "id-test".to_string(),
+            pair_identity_label: String::new(),
+            pair_code_hash: String::new(),
             remote_service_install_enabled: false,
             remote_service_install_timeout_secs: 300,
             authorized_control_device_pks: HashSet::new(),

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -2,9 +2,15 @@
 //!
 //! Provides event construction, signing, verification, and websocket frame helpers.
 
+use aes::Aes256;
 use anyhow::{anyhow, Result};
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine as _;
+use cbc::cipher::block_padding::Pkcs7;
+use cbc::cipher::{BlockDecryptMut, KeyIvInit};
+use secp256k1::ecdh;
 use secp256k1::schnorr::Signature;
-use secp256k1::{Keypair, Secp256k1, SecretKey, XOnlyPublicKey};
+use secp256k1::{Keypair, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -124,6 +130,40 @@ pub fn verify_event(ev: &NostrEvent) -> Result<bool> {
     let secp = Secp256k1::new();
     Ok(secp.verify_schnorr(&sig, &hash, &pk).is_ok())
 }
+
+pub fn nip04_decrypt(sk_hex: &str, sender_pk_hex: &str, ciphertext: &str) -> Result<String> {
+    let sk_bytes = hex_to_bytes(sk_hex)?;
+    let sk = SecretKey::from_slice(&sk_bytes).map_err(|_| anyhow!("invalid nostr sk"))?;
+    let sender_pk = parse_nostr_pubkey(sender_pk_hex)?;
+
+    let shared_point = ecdh::shared_secret_point(&sender_pk, &sk);
+    let key = &shared_point[..32];
+
+    let (cipher_b64, iv_b64) = ciphertext
+        .trim()
+        .split_once("?iv=")
+        .ok_or_else(|| anyhow!("invalid nip04 payload"))?;
+
+    let iv = B64
+        .decode(iv_b64.trim())
+        .map_err(|_| anyhow!("invalid nip04 iv"))?;
+    if iv.len() != 16 {
+        return Err(anyhow!("invalid nip04 iv length"));
+    }
+
+    let encrypted = B64
+        .decode(cipher_b64.trim())
+        .map_err(|_| anyhow!("invalid nip04 ciphertext"))?;
+
+    let cipher = cbc::Decryptor::<Aes256>::new_from_slices(key, &iv)
+        .map_err(|_| anyhow!("invalid nip04 key/iv"))?;
+    let plaintext = cipher
+        .decrypt_padded_vec_mut::<Pkcs7>(&encrypted)
+        .map_err(|_| anyhow!("nip04 decrypt failed"))?;
+
+    String::from_utf8(plaintext).map_err(|_| anyhow!("nip04 plaintext is not utf8"))
+}
+
 pub fn event_id_hex(unsigned: &NostrUnsignedEvent) -> Result<String> {
     let content = json!([
         0,
@@ -136,6 +176,17 @@ pub fn event_id_hex(unsigned: &NostrUnsignedEvent) -> Result<String> {
     let raw = serde_json::to_string(&content).map_err(|_| anyhow!("event serialize failed"))?;
     let digest = Sha256::digest(raw.as_bytes());
     Ok(bytes_to_hex(digest.as_slice()))
+}
+
+fn parse_nostr_pubkey(pk_hex: &str) -> Result<PublicKey> {
+    let xonly = hex_to_bytes(pk_hex)?;
+    if xonly.len() != 32 {
+        return Err(anyhow!("invalid nostr pubkey"));
+    }
+    let mut compressed = Vec::with_capacity(33);
+    compressed.push(0x02);
+    compressed.extend_from_slice(&xonly);
+    PublicKey::from_slice(&compressed).map_err(|_| anyhow!("invalid nostr pubkey"))
 }
 
 fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
@@ -161,4 +212,40 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
 fn xonly_pk_hex(keypair: &Keypair) -> String {
     let (pk, _) = XOnlyPublicKey::from_keypair(keypair);
     bytes_to_hex(&pk.serialize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generate_keypair, hex_to_bytes, nip04_decrypt, parse_nostr_pubkey, B64};
+    use aes::Aes256;
+    use base64::Engine as _;
+    use cbc::cipher::block_padding::Pkcs7;
+    use cbc::cipher::{BlockEncryptMut, KeyIvInit};
+    use secp256k1::ecdh;
+    use secp256k1::SecretKey;
+
+    #[test]
+    fn nip04_decrypt_roundtrip() {
+        let (sender_pk, sender_sk) = generate_keypair();
+        let (receiver_pk, receiver_sk) = generate_keypair();
+
+        let sender_secret =
+            SecretKey::from_slice(&hex_to_bytes(&sender_sk).expect("sender sk bytes"))
+                .expect("sender sk");
+        let receiver_public = parse_nostr_pubkey(&receiver_pk).expect("receiver pk");
+        let shared_point = ecdh::shared_secret_point(&receiver_public, &sender_secret);
+        let key = &shared_point[..32];
+
+        let iv = [7u8; 16];
+        let plaintext = br#"{"identityId":"id-42","devices":[{"pk":"abc","label":"Gateway"}]}"#;
+        let cipher = cbc::Encryptor::<Aes256>::new_from_slices(key, &iv).expect("cipher");
+        let encrypted = cipher.encrypt_padded_vec_mut::<Pkcs7>(plaintext);
+        let payload = format!("{}?iv={}", B64.encode(&encrypted), B64.encode(iv));
+
+        let decrypted = nip04_decrypt(&receiver_sk, &sender_pk, &payload).expect("decrypt");
+        assert_eq!(
+            decrypted,
+            String::from_utf8(plaintext.to_vec()).expect("utf8")
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- accept and validate encrypted pair_approve payloads before resolving pairing
- persist the resolved identity_id and approved device label into encrypted keystore state
- stop mutating live runtime config while writing the redacted persisted config.json
- skip repeat enrollment publication when the gateway is already paired
- add tests for NIP-04 decrypt and keystore identity persistence
- document the controlled restart after approval

## Validation
- cargo test --quiet

Closes #29