### PR TITLE
feat(gateway): add managed NVR launch and signaling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,34 +1,40 @@
 # Constitute Gateway Architecture
 
-This document captures the gateway architecture, convergence requirements with the web repo, and the current roadmap.
+This document captures the gateway architecture, convergence requirements with the browser shell, and the active roadmap direction.
 
 Roadmap brief companion: [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 ## Purpose
-The gateway is a native dependency that enables browser clients to bootstrap discovery, bridge into swarm transport, and consume DHT-backed primitives. It is not a parallel product surface.
+The gateway is the canonical browser control-plane boundary for managed Constitution services.
+It is not the permanent UI container for first-party apps, and it is not a parallel product surface.
 
-## Alignment With Web Repo
-Authoritative reference: `https://github.com/Aux0x7F/constitute`.
+## Alignment With Other Repos
+The active contract slice aligns with:
+- `constitute` for management shell and launch
+- `constitute-nvr` for hosted service inventory and live preview signaling
+- `constitute-nvr-ui` for managed app surface bootstrap
 
 Required convergence points:
-- Identity model: Nostr device keypair
-- Signed NIP-01 events
-- Discovery record schema (`kind=30078`, `t=swarm_discovery`, `type=device`)
-- Zone presence envelope (`kind=1`, `t=constitute`, `z=<zone>`, `type=zone_presence`)
-- Shared role vocabulary (`relay|gateway|browser|native`)
+- service-backed device publication
+- hosted service inventory and freshness
+- launch authorization for managed app surfaces
+- gateway-mediated WebRTC signaling
+- zone and identity durability semantics
 
 ## Core Responsibilities
 1. Discovery bootstrap via Nostr relays
 2. Zone-scoped presence and peer discovery
-3. Local gateway relay for browser peers (WS/WSS)
+3. Browser relay/app-channel surface
 4. Swarm record storage for identity/device/DHT records
 5. UDP + QUIC handshake and request forwarding across native peers
-6. External endpoint publication for swarm advertisement
+6. Hosted-service inventory publication
+7. Managed launch authorization and signaling brokerage
 
 ## Identity and Key Management
 - On first run, gateway generates a Nostr keypair and persists it.
-- Public key is gateway identity (`devicePk`).
-- Discovery and signaling events are signed.
+- Public key is the gateway device identity (`devicePk`).
+- Gateway is a service-backed device with `deviceKind = service`.
+- Discovery, status, and signaling events are signed.
 - Private key remains local by default.
 
 Key storage:
@@ -39,15 +45,22 @@ Key storage:
   3. Local fallback key file (`keystore.key`)
 
 ## Discovery and Presence Contracts
+
 ### Swarm Discovery Record
 - `kind`: `30078`
 - Tags: `['t','swarm_discovery']`, `['type','device']`, `['role','<role>']`
 - Content fields include:
-  - `devicePk`, optional `identityId`, optional `deviceLabel`
+  - `devicePk`
+  - optional `identityId`, `deviceLabel`
   - `updatedAt`, `expiresAt`
-  - `role` (`relay|gateway|browser|native`; runtime defaults to `gateway` but is configurable)
+  - `role`
+  - `deviceKind` (`user|service`, gateway publishes `service`)
+  - optional `service`
+  - optional `hostGatewayPk` for hosted service-backed devices
   - `relays`
+  - `hostPlatform`
   - `serviceVersion`
+  - optional hosted-service inventory and freshness fields
 
 ### Zone Presence
 - `kind`: `1`
@@ -56,96 +69,74 @@ Key storage:
   - `type: zone_presence`
   - `zone`, `devicePk`
   - `swarm` endpoint
-  - `role`, `relays`, `serviceVersion`, `metrics`
+  - `role`, `relays`, `hostPlatform`, `serviceVersion`
+  - `metrics`
   - `ts`, `ttl`
 
+## Hosted Service Model
+Gateway may host multiple service-backed devices on the same machine.
+
+For each hosted service the gateway should be able to publish:
+- service slug (`nvr`)
+- hosted service device key
+- `hostGatewayPk`
+- version
+- freshness / last-seen
+- launch availability / managed status
+
+Gateway owns:
+- install/update/control requests
+- launch authorization
+- signaling brokerage
+- service inventory
+
+Gateway does not need to be the long-term UI container for those services.
+
+## Managed Launch Model
+Canonical flow:
+1. browser shell selects an owned gateway
+2. browser shell requests managed launch for a hosted service
+3. gateway validates identity membership, device authorization, and capability
+4. gateway issues short-lived launch authorization
+5. browser app surface uses gateway-mediated signaling to establish WebRTC with the hosted service
+6. hosted service validates the gateway-issued authorization before admitting the session
+
+## WebRTC Direction
+Gateway is the signaling/control boundary for browser-safe direct paths:
+- same-LAN clients should win via ICE host candidates
+- NAT-friendly remote clients may win via server reflexive candidates
+- hard-NAT fallback via TURN remains a later slice unless operator TURN is already available
+
+Gateway should not force all media through itself if a direct authorized browser-to-service session is available.
+
 ## Zone and Overlay Direction
-- UDP gossip is zone-scoped.
+- UDP gossip remains zone-scoped.
 - Gateways may join multiple zones.
 - Effective gateway zone scope is `identity zones + gateway extra zones`.
-- Identity zones are synced from owner web clients; extra zones are gateway-specific overrides from gateway settings.
-- Records are stored per-zone and not auto-bridged across zones.
-
-Future overlay model:
-- Communities can span zones via explicit routing/invites.
-- Coalitions group communities and can define shared interop channels.
-- Cross-zone routing remains opt-in to reduce metadata leakage.
+- Records remain stored per-zone and are not auto-bridged across zones.
 
 ## Update Distribution Direction
 Current model:
-- Gateways poll GitHub tagged releases (`releases/latest`).
-- Poll interval is operator-configured (`--timer-interval`) with development override (`--dev-poll`).
-- Egress policy is operator-managed (direct/proxy/tunnel).
+- gateways poll GitHub tagged releases
+- poll interval is operator-configured
+- egress policy is operator-managed
 
-Planned model:
-- Optional proxy/Tor egress helper flows.
-- Signed `update_available` announcements from web devices.
-- Optional no-clearnet mode where release payloads arrive via trusted network peers.
-
-## Host Baseline and Hardening
-Baseline:
-- Linux or Windows host managed by operator.
-- No repository-managed OS image/media build path.
-
-Operational hardening:
-- Bounded firewall rules for explicit ports only
-- Systemd service limits and restart policy (Linux)
-- Minimal logging by default
-
-## Threat Model
-Assume high-surveillance environments:
-- Discovery metadata is observable.
-- Transport endpoints are correlatable without operator OPSEC.
-
-Operational guidance:
-- Use VPN/tunnel controls based on risk profile.
-- Treat transport as delivery substrate, not confidentiality boundary.
-- Enforce encryption at identity/application layers.
+Planned extensions:
+- signed update metadata verification
+- signed `update_available` announcements
+- optional proxy/Tor and no-clearnet flows
 
 ## Security Posture
 Current guarantees:
-- Signed discovery events
-- Encrypted key material at rest
-- Replay mitigation in relay paths
-- DHT/record validation before acceptance
+- signed discovery/status events
+- encrypted key material at rest
+- replay mitigation in relay paths
+- record validation before acceptance
 
-Planned hardening:
-- Config integrity validation and migration guards
-- Signed release metadata verification
-- Stronger host config update verification path
-
-## Roadmap
-Execution order:
-1. Finish gateway contract freeze and parity gaps in this repository.
-2. Converge web implementation against frozen contracts.
-3. Build service-layer repos (starting with `constitute-nvr`) on top of the converged base.
-
-### Phase 0: Bootstrap Parity
-- [x] Nostr keypair generation and signed events
-- [x] Zone presence and discovery schema alignment
-- [x] Local gateway relay
-- [x] DHT put/get bridge for app-channel + UDP lookup
-- [x] Basic metrics publication
-
-### Phase 1: Swarm Transport
-- [x] Stable mesh transport baseline (`udp + optional quic`)
-- [x] Relay fallback strategy (`udp <-> quic` dual-send + graceful degrade)
-- [x] TURN/gateway role boundaries documented (browser TURN remains client-side fallback)
-
-### Phase 2: Host and Service Hardening
-- [x] Operator-managed release update timer path
-- [ ] Signature-verified release payload enforcement
-- [ ] Non-root runtime hardening profile completion
-
-### Phase 3: Web Convergence
-- [~] DHT contract convergence (gateway side implemented, web side pending)
-- [ ] Shared identity/device resolution behavior parity
-- [ ] Zone membership durability and sync behavior parity
-
-### Future Milestone: Managed Gateways
-- [ ] Identity-owned gateway fleet management in web surface
-- [ ] Signed update broadcasts from web devices
-- [ ] Optional no-clearnet gateway update mode
+Active sprint direction:
+- short-lived launch authorization
+- capability-enforced managed service launch
+- gateway-mediated signaling without leaking long-lived browser secrets to app surfaces
 
 ## Documentation Surface
 - `README.md`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rcgen",
+ "reqwest",
  "rustls",
  "rustls-pemfile",
  "secp256k1",
@@ -1588,6 +1589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,10 +1975,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icu_collections"
@@ -2132,6 +2225,22 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2615,7 +2724,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -3439,6 +3548,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3703,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3705,6 +3858,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3932,6 +4097,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -4201,6 +4375,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4480,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -4410,6 +4635,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constitute-gateway"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ quinn = { version = "0.11", default-features = false, features = ["runtime-tokio
 rcgen = "0.13"
 rustls = { version = "0.23", features = ["ring"] }
 eframe = { version = "0.29", optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time", "net", "sync"] }

--- a/config.example.json
+++ b/config.example.json
@@ -3,11 +3,11 @@
   "bind": "0.0.0.0:4040",
   "data_dir": "./data",
   "nostr_relays": [
-    "wss://relay.snort.social"
+    "wss://nos.lol",
+    "wss://relay.primal.net",
+    "wss://nostr.mom"
   ],
-  "advertise_relays": [
-    "ws://gateway.example:7447"
-  ],
+  "advertise_relays": [],
   "nostr_kind": 30078,
   "nostr_tag": "swarm_discovery",
   "nostr_publish_interval_secs": 30,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -4,7 +4,7 @@ This document defines the protocol contract for `constitute-gateway` and the exp
 
 ## Contract Status
 - Status: `active`
-- Scope: gateway runtime, web<->gateway app channel, gateway<->gateway transport
+- Scope: gateway runtime, web<->gateway app channel, managed service launch/signaling, gateway<->gateway transport
 - Compatibility rule: additive changes only unless a version gate is introduced and implemented on both gateway and web
 
 ## Canonical Terms
@@ -12,6 +12,10 @@ This document defines the protocol contract for `constitute-gateway` and the exp
 - `identityId`: logical identity identifier
 - `zone`: discovery/replication partition key
 - `record`: signed Nostr event carrying `identity`, `device`, or `dht` payload
+- `deviceKind`: `user` or `service`
+- `service`: service slug for service-backed devices
+- `hostGatewayPk`: gateway device public key that hosts a service-backed device
+- `launchToken`: short-lived gateway-issued authorization for managed app launch/session setup
 
 ## Node Roles
 The role vocabulary is shared across discovery and presence payloads:
@@ -41,12 +45,17 @@ Content fields:
 - `updatedAt` (required, ms)
 - `expiresAt` (required, ms)
 - `role` (required)
+- `deviceKind` (optional; defaults to `user`)
+- `service` (optional)
+- `hostGatewayPk` (optional)
 - `relays` (array, optional)
 - `hostPlatform` (optional; `linux`, `windows`, or `unknown`)
 - `serviceVersion` (required)
 - `releaseChannel` (optional; `release` or `dev`)
 - `releaseTrack` (optional; `latest` or custom track)
 - `releaseBranch` (optional; branch name for local/dev installs)
+- `hostedServices` (optional array, gateway only)
+- `freshnessMs` (optional)
 
 ### 2) Zone Presence
 Signed Nostr event:
@@ -149,6 +158,82 @@ Gateway status events:
 - status lifecycle: `accepted` -> `started` -> (`complete` | `failed` | `rejected`)
 - includes `requestId`, `gatewayPk`, `toDevicePk`, `identityId`, `service`, `action`, optional `reason`/`detail`
 
+### Request: Managed Service Launch
+Incoming type:
+- `gateway_managed_launch_request`
+
+Required fields:
+- `requestId`
+- `toDevicePk` (must match gateway `devicePk`)
+- `identityId`
+- `devicePk` (requesting paired browser device)
+- `servicePk` (target hosted service-backed device)
+- `service`
+- `capability` (for example `nvr.view` or `nvr.manage`)
+- `launchNonce`
+
+Optional fields:
+- `zone`
+- `appRepo`
+- `display`
+
+Gateway responses:
+- `gateway_managed_launch_status`
+- lifecycle: `accepted` -> (`complete` | `failed` | `rejected`)
+- `complete` includes:
+  - `gatewayPk`
+  - `servicePk`
+  - `service`
+  - `launchToken`
+  - `expiresAt`
+  - optional `display`
+
+Validation rules:
+- requesting device must belong to the same identity as the gateway runtime
+- target service must be owned/hosted by the gateway
+- requesting device must hold the requested capability
+- launch token must be short-lived and service-scoped
+
+### Request: Managed Service Signaling
+Incoming type:
+- `gateway_signal_request`
+
+Required fields:
+- `requestId`
+- `toDevicePk` (must match gateway `devicePk`)
+- `identityId`
+- `devicePk` (requesting browser device)
+- `servicePk`
+- `service`
+- `signalType`
+- `payload`
+- `launchToken`
+
+`signalType` values for MVP:
+- `offer`
+- `answer`
+- `ice_candidate`
+- `ice_complete`
+- `session_close`
+
+Gateway responses:
+- `gateway_signal_status`
+- lifecycle: `accepted` -> (`complete` | `failed` | `rejected`)
+
+Gateway forwarding events:
+- `gateway_signal`
+- delivered to the target hosted service or requesting browser path with:
+  - `gatewayPk`
+  - `servicePk`
+  - `service`
+  - `signalType`
+  - `payload`
+
+Validation rules:
+- launch token must still be valid
+- token must bind the requesting device, target gateway, and target service
+- gateway may reject signaling that is not associated with an active launch/session
+
 ### Request: Gateway Zone Sync
 Incoming type:
 - `gateway_zone_sync_request`
@@ -207,6 +292,14 @@ Runtime behavior:
 - TURN remains a browser/client fallback path when direct browser connectivity is required.
 - Gateway mesh transport (UDP/QUIC) is the native backbone plane.
 
+## Managed Service Media Direction
+- Gateway is the control/signaling boundary for browser-managed service access.
+- Browser media path for managed live view is WebRTC.
+- Preview codec direction is H.264.
+- Same-LAN host ICE candidates are preferred.
+- NAT-friendly server reflexive candidates are allowed.
+- Hard-NAT guaranteed fallback via TURN is not required for this iteration unless operator TURN is present.
+
 ## Validation and Security Invariants
 
 ### Relay Ingest (WS/WSS)
@@ -234,11 +327,19 @@ Record acceptance requires:
 - Rebroadcast excludes events authored by self.
 - Allowed relay fanout classes are constrained to `t=constitute` or `t=swarm_discovery`.
 
+### Managed Launch Security
+- launch tokens must expire quickly
+- launch tokens must bind gateway, service, identity, and requesting device
+- services must reject invalid, expired, unsigned, or wrong-target launch tokens
+- browser launch/bootstrap must not rely on long-lived secrets in URL parameters
+
 ## Convergence Targets (Gateway -> Web)
-The following are executed during web convergence to validate parity; gateway-side transport/fallback/auth baselines are complete for iteration-1:
-- exact signaling envelope parity for swarm signaling messages
-- parity for identity/device resolution behavior and fallback order
-- parity for zone membership durability and sync semantics
+The following are executed during convergence:
+- service-backed device record parity
+- managed launch authorization parity
+- managed signaling envelope parity
+- identity/device resolution behavior and fallback order
+- zone membership durability and sync semantics
 - shared test vectors for accepted/rejected envelopes
 
 ## Versioning Policy

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,77 +1,87 @@
 # Project Roadmap Brief
 
-This brief captures execution order across `constitute-gateway`, `constitute` (web), and `constitute-nvr`.
+This brief captures execution order across `constitute-gateway`, `constitute`, `constitute-nvr`, and `constitute-nvr-ui`.
 
 ## Delivery Strategy
-1. Stabilize and freeze gateway contracts.
-2. Converge web implementation against those contracts.
-3. Add higher-level services (starting with `constitute-nvr`) on top of the converged base.
+1. Freeze cross-repo contracts for service-backed devices and managed app surfaces.
+2. Implement gateway-managed launch/signaling.
+3. Implement NVR live preview over managed WebRTC.
+4. Converge shell and app surfaces against the managed-service contract.
 
 Rationale:
-- Gateway is the transport/control dependency for web and native service clients.
-- Contract stability reduces thrash during web convergence.
-- Service-layer work (NVR and similar) should consume stable primitives, not redefine them.
+- Gateway is the browser control dependency for managed services.
+- Contract stability reduces cross-repo thrash.
+- App surfaces should consume stable launch/signaling primitives, not redefine auth or transport.
 
 ## Current Snapshot
-- Gateway: core discovery, app-channel bridge, zone-scoped UDP/DHT path, optional QUIC mesh path, and gateway zone-sync control contract implemented.
-- Web convergence: partial; parity work remains.
-- NVR: service installation/status contract implemented in gateway; broader integration remains in sibling repos.
+- Gateway: discovery, app-channel bridge, zone-scoped UDP/DHT path, optional QUIC mesh path, and gateway zone-sync/install contracts implemented.
+- Managed-service launch/signaling: active implementation slice.
+- NVR: service install path exists; live preview and managed launch parity remain active work.
 
 ## Phase Plan
 
-### Phase A: Gateway Contract Freeze
+### Phase A: Contract Freeze
 Objectives:
 - finalize protocol contracts in `docs/PROTOCOL.md`
-- close remaining transport/runtime gaps needed for parity
-- keep security invariants test-backed
+- align repo-local docs with the project-level service-backed device and app-surface model
+- keep security invariants explicit before code churn
 
 Exit criteria:
-- contract doc reviewed and stable
-- gateway tests green in CI for Linux and Windows
-- no unresolved P0 parity blockers in gateway architecture roadmap
+- contract docs reviewed and stable across repos
+- compatibility defaults documented
+- no unresolved schema ambiguity for launch/signaling records
 
-### Phase B: Web Convergence
+### Phase B: Gateway Managed Launch and Signaling
 Objectives:
-- align `constitute` web event envelopes and request/response flows
-- match identity/device lookup behavior with gateway
-- validate zone durability and sync behavior end-to-end
+- publish service-backed device metadata and hosted-service inventory
+- issue short-lived managed launch authorization
+- broker browser <-> service signaling for WebRTC
+- expose gateway/service freshness and status cleanly
 
 Exit criteria:
-- cross-repo compatibility test plan passes
-- no schema drift between web and gateway contracts
-- web fallback path validated: relay <-> gateway path behaves deterministically
+- launch authorization tests pass
+- signaling contract tests pass
+- hosted-service inventory publishes deterministically
+- same-LAN and NAT-friendly paths have a consistent gateway signaling story
 
-### Phase C: Service Layer (NVR First)
+### Phase C: NVR Managed Live View
 Objectives:
-- implement `constitute-nvr` as a separate native service/client
-- publish service capability and endpoint metadata via contract-compliant records
-- keep gateway focused on transport/control plane, not NVR app internals
+- publish NVR as a service-backed device hosted by a gateway
+- implement gateway-authorized WebRTC H.264 live preview
+- preserve encrypted recording and segment retrieval
+- keep direct/manual debug mode available but non-canonical
 
 Exit criteria:
-- NVR service advertises and resolves over converged gateway/web contracts
-- NVR ingestion/retention/auth flows are isolated to service layer
-- operational runbook includes co-hosted and split-host deployment models
+- at least one live preview tile renders through managed launch
+- multiple preview tiles can coexist using substreams where available
+- archived segment retrieval still works
+
+### Phase D: Shell and App Surface Convergence
+Objectives:
+- make `constitute` a clean management shell plus launcher
+- make `constitute-nvr-ui` a clean Pages-hosted app surface
+- remove long-lived secret expectations from managed app launch
+
+Exit criteria:
+- first-party app launch opens separate app surface cleanly
+- shell surfaces service-backed devices distinctly from user devices
+- launch context/bootstrap works without query-string secrets
 
 ## Known Risks and Controls
-- Risk: gateway/web contract drift during active iteration.
+- Risk: contract drift during active iteration.
   - Control: protocol-first changes and compatibility test vectors.
-- Risk: transport changes break app-channel assumptions.
-  - Control: end-to-end contract tests before web merge.
-- Risk: service scope bleeding into gateway core.
-  - Control: strict boundary; services consume gateway APIs/events.
+- Risk: WebRTC complexity slows delivery.
+  - Control: keep gateway as signaling boundary and preserve recorded-media fallback.
+- Risk: shell/app bootstrap leaks secrets.
+  - Control: short-lived launch tokens and non-secret launch ids only.
 
 ## Near-Term Priority Order
-1. finish gateway parity gaps called out in `ARCHITECTURE.md`
-2. execute web convergence pass
-3. continue `constitute-nvr` integration against converged contracts
+1. freeze service-backed device and managed-launch docs
+2. land gateway launch/signaling implementation
+3. land NVR live preview path
+4. converge shell and NVR UI
 
 ## Install/Deploy Model (Current)
 - No repository-managed OS image/media generation path.
 - Dev: clone repository, build locally, install service locally.
 - Release: install/update service from tagged release artifacts.
-
-## Estimation Guidance
-To account for offline human intervals and review latency:
-- apply a 1.5x to 2.0x calendar buffer to implementation estimates
-- split work into issue-sized slices that each close within 1-3 focused sessions
-- prefer milestone-level target dates over single-day deadlines for integration-heavy phases

--- a/scripts/linux/install-service.sh
+++ b/scripts/linux/install-service.sh
@@ -156,7 +156,7 @@ DEFAULT_NOSTR_RELAYS="wss://nos.lol,wss://relay.primal.net,wss://nostr.mom"
 LAN_RELAY_IP=""
 RELAY_PORT="7447"
 if command -v ip >/dev/null 2>&1; then
-  LAN_RELAY_IP="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i == \"src\") { print $(i+1); exit }}')"
+  LAN_RELAY_IP="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i == "src") { print $(i+1); exit }}')"
 fi
 
 if [[ -f "$CONFIG_DIR/config.json" ]]; then

--- a/scripts/linux/install-service.sh
+++ b/scripts/linux/install-service.sh
@@ -152,13 +152,21 @@ if [[ -n "$CONFIG_TEMPLATE" && -f "$CONFIG_TEMPLATE" && ! -f "$CONFIG_DIR/config
   run_sudo install -m 0644 "$CONFIG_TEMPLATE" "$CONFIG_DIR/config.json"
 fi
 
+DEFAULT_NOSTR_RELAYS="wss://nos.lol,wss://relay.primal.net,wss://nostr.mom"
+LAN_RELAY_IP=""
+RELAY_PORT="7447"
+if command -v ip >/dev/null 2>&1; then
+  LAN_RELAY_IP="$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for (i=1;i<=NF;i++) if ($i == \"src\") { print $(i+1); exit }}')"
+fi
+
 if [[ -f "$CONFIG_DIR/config.json" ]]; then
   if ! command -v python3 >/dev/null 2>&1; then
     echo "python3 is required to normalize config data_dir" >&2
     exit 1
   fi
-  run_sudo python3 - "$CONFIG_DIR/config.json" "$DATA_DIR" <<'PY'
+  run_sudo env DEFAULT_NOSTR_RELAYS="$DEFAULT_NOSTR_RELAYS" LAN_RELAY_IP="$LAN_RELAY_IP" RELAY_PORT="$RELAY_PORT" python3 - "$CONFIG_DIR/config.json" "$DATA_DIR" <<'PY'
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -178,6 +186,26 @@ elif normalized.startswith("/"):
     cfg["data_dir"] = normalized
 else:
     cfg["data_dir"] = f"{state_root}/{normalized.lstrip('./')}"
+
+default_relays = [item.strip() for item in os.environ.get("DEFAULT_NOSTR_RELAYS", "").split(",") if item.strip()]
+existing_relays = [str(item).strip() for item in cfg.get("nostr_relays", []) if str(item).strip()]
+legacy_defaults = {"wss://relay.snort.social", "wss://relay.damus.io"}
+if not existing_relays or set(existing_relays).issubset(legacy_defaults):
+    cfg["nostr_relays"] = default_relays
+
+relay_port = str(os.environ.get("RELAY_PORT", "7447")).strip() or "7447"
+host_ip = str(os.environ.get("LAN_RELAY_IP", "")).strip()
+existing_advertise = [str(item).strip() for item in cfg.get("advertise_relays", []) if str(item).strip()]
+placeholder_hosts = {"gateway.example", "replace-host"}
+
+def relay_is_placeholder(url: str) -> bool:
+    if not url:
+        return True
+    lowered = url.lower()
+    return any(host in lowered for host in placeholder_hosts) or lowered.endswith(".example:7447")
+
+if host_ip and (not existing_advertise or all(relay_is_placeholder(item) for item in existing_advertise)):
+    cfg["advertise_relays"] = [f"ws://{host_ip}:{relay_port}"]
 
 with cfg_path.open("w", encoding="utf-8") as f:
     json.dump(cfg, f, indent=2)

--- a/scripts/windows/install-service.ps1
+++ b/scripts/windows/install-service.ps1
@@ -108,6 +108,38 @@ function Normalize-Config {
         $cfg | Add-Member -NotePropertyName data_dir -NotePropertyValue $resolved -Force
     }
 
+    $defaultRelays = @('wss://nos.lol', 'wss://relay.primal.net', 'wss://nostr.mom')
+    $legacyRelays = @('wss://relay.snort.social', 'wss://relay.damus.io')
+    $existingRelays = @()
+    if ($null -ne $cfg.nostr_relays) {
+        $existingRelays = @($cfg.nostr_relays | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+    $hasCustomRelay = ($existingRelays | Where-Object { $_ -notin $legacyRelays }).Count -gt 0
+    if ($existingRelays.Count -eq 0 -or -not $hasCustomRelay) {
+        $cfg | Add-Member -NotePropertyName nostr_relays -NotePropertyValue $defaultRelays -Force
+    }
+
+    $existingAdvertise = @()
+    if ($null -ne $cfg.advertise_relays) {
+        $existingAdvertise = @($cfg.advertise_relays | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+    $placeholderAdvertise = $existingAdvertise | Where-Object { $_ -match 'gateway\.example|replace-host|\.example(?::|/|$)' }
+    $needsAdvertise = $existingAdvertise.Count -eq 0 -or $placeholderAdvertise.Count -eq $existingAdvertise.Count
+    if ($needsAdvertise) {
+        $defaultRoute = Get-NetRoute -DestinationPrefix '0.0.0.0/0' -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+            Sort-Object RouteMetric, InterfaceMetric |
+            Select-Object -First 1
+        $lanIp = $null
+        if ($defaultRoute) {
+            $lanIp = Get-NetIPAddress -InterfaceIndex $defaultRoute.InterfaceIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+                Where-Object { $_.IPAddress -and $_.IPAddress -notlike '169.254*' } |
+                Select-Object -First 1 -ExpandProperty IPAddress
+        }
+        if (-not [string]::IsNullOrWhiteSpace($lanIp)) {
+            $cfg | Add-Member -NotePropertyName advertise_relays -NotePropertyValue @("ws://$lanIp:7447") -Force
+        }
+    }
+
     $existingIdentity = [string]$cfg.pair_identity_label
     $existingCode = [string]$cfg.pair_code
     $existingHash = [string]$cfg.pair_code_hash

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::time::Duration;
 use tokio::sync::watch;
 
@@ -154,7 +155,33 @@ impl SwarmDeviceRecord {
     }
 
     pub fn to_json(&self) -> String {
-        serde_json::to_string(self).unwrap_or_else(|_| "{}".to_string())
+        serde_json::to_string(&self.as_json_value()).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    fn as_json_value(&self) -> serde_json::Value {
+        json!({
+            "devicePk": self.device_pk,
+            "identityId": self.identity_id,
+            "deviceLabel": self.device_label,
+            "updatedAt": self.updated_at,
+            "expiresAt": self.expires_at,
+            "role": self.role,
+            "deviceKind": self.device_kind,
+            "service": self.service,
+            "hostGatewayPk": self.host_gateway_pk,
+            "relays": self.relays,
+            "hostPlatform": self.host_platform,
+            "serviceVersion": self.service_version,
+            "releaseChannel": self.release_channel,
+            "releaseTrack": self.release_track,
+            "releaseBranch": self.release_branch,
+            "freshnessMs": self.freshness_ms,
+            "hostedServices": self
+                .hosted_services
+                .iter()
+                .map(HostedServiceRecord::as_json_value)
+                .collect::<Vec<_>>(),
+        })
     }
 }
 
@@ -197,6 +224,23 @@ pub struct DiscoveryClient {
     swarm_endpoint_rx: watch::Receiver<String>,
     metrics_rx: watch::Receiver<GatewayMetrics>,
     hosted_services_rx: watch::Receiver<Vec<HostedServiceRecord>>,
+}
+
+impl HostedServiceRecord {
+    fn as_json_value(&self) -> serde_json::Value {
+        json!({
+            "devicePk": self.device_pk,
+            "deviceLabel": self.device_label,
+            "deviceKind": self.device_kind,
+            "service": self.service,
+            "hostGatewayPk": self.host_gateway_pk,
+            "serviceVersion": self.service_version,
+            "updatedAt": self.updated_at,
+            "freshnessMs": self.freshness_ms,
+            "status": self.status,
+            "cameraCount": self.camera_count,
+        })
+    }
 }
 
 impl DiscoveryClient {
@@ -346,4 +390,41 @@ fn default_release_track() -> String {
 
 pub fn service_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HostedServiceRecord, SwarmDeviceRecord};
+
+    #[test]
+    fn device_record_json_keeps_device_kind_and_hosted_services() {
+        let mut record = SwarmDeviceRecord::new(
+            "gateway-pk",
+            "identity-id",
+            "DevGateway",
+            "gateway",
+            vec!["ws://gateway.example:7447".to_string()],
+            "linux",
+            "release",
+            "latest",
+            "",
+        );
+        record.hosted_services.push(HostedServiceRecord {
+            device_pk: "service-pk".to_string(),
+            device_label: "Constitute NVR".to_string(),
+            device_kind: "service".to_string(),
+            service: "nvr".to_string(),
+            host_gateway_pk: "gateway-pk".to_string(),
+            service_version: "0.1.0".to_string(),
+            updated_at: 123,
+            freshness_ms: 0,
+            status: "online".to_string(),
+            camera_count: 1,
+        });
+
+        let json = record.to_json();
+        assert!(json.contains("\"deviceKind\":\"service\""));
+        assert!(json.contains("\"hostedServices\":["));
+        assert!(json.contains("\"service\":\"nvr\""));
+    }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -68,6 +68,24 @@ pub struct GatewayMetrics {
     pub ts: u64,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedServiceRecord {
+    pub device_pk: String,
+    pub device_label: String,
+    pub device_kind: String,
+    pub service: String,
+    pub host_gateway_pk: String,
+    pub service_version: String,
+    pub updated_at: u64,
+    #[serde(default)]
+    pub freshness_ms: u64,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub camera_count: u64,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SwarmDeviceRecord {
@@ -77,6 +95,12 @@ pub struct SwarmDeviceRecord {
     pub updated_at: u64,
     pub expires_at: u64,
     pub role: String,
+    #[serde(default = "default_device_kind")]
+    pub device_kind: String,
+    #[serde(default)]
+    pub service: String,
+    #[serde(default)]
+    pub host_gateway_pk: String,
     #[serde(default)]
     pub relays: Vec<String>,
     #[serde(default)]
@@ -89,6 +113,10 @@ pub struct SwarmDeviceRecord {
     pub release_track: String,
     #[serde(default)]
     pub release_branch: String,
+    #[serde(default)]
+    pub freshness_ms: u64,
+    #[serde(default)]
+    pub hosted_services: Vec<HostedServiceRecord>,
 }
 
 impl SwarmDeviceRecord {
@@ -111,12 +139,17 @@ impl SwarmDeviceRecord {
             updated_at: now,
             expires_at: now + RECORD_TTL_MS,
             role: role.to_string(),
+            device_kind: default_device_kind(),
+            service: String::new(),
+            host_gateway_pk: String::new(),
             relays,
             host_platform: host_platform.to_string(),
             service_version: service_version(),
             release_channel: release_channel.to_string(),
             release_track: release_track.to_string(),
             release_branch: release_branch.to_string(),
+            freshness_ms: 0,
+            hosted_services: Vec::new(),
         }
     }
 
@@ -163,6 +196,7 @@ pub struct DiscoveryClient {
     zones: Vec<String>,
     swarm_endpoint_rx: watch::Receiver<String>,
     metrics_rx: watch::Receiver<GatewayMetrics>,
+    hosted_services_rx: watch::Receiver<Vec<HostedServiceRecord>>,
 }
 
 impl DiscoveryClient {
@@ -175,6 +209,7 @@ impl DiscoveryClient {
         zones: Vec<String>,
         swarm_endpoint_rx: watch::Receiver<String>,
         metrics_rx: watch::Receiver<GatewayMetrics>,
+        hosted_services_rx: watch::Receiver<Vec<HostedServiceRecord>>,
     ) -> Self {
         Self {
             pool,
@@ -185,6 +220,7 @@ impl DiscoveryClient {
             zones,
             swarm_endpoint_rx,
             metrics_rx,
+            hosted_services_rx,
         }
     }
 
@@ -219,12 +255,17 @@ impl DiscoveryClient {
     }
 
     fn device_record_json(&self) -> Result<String> {
+        let mut record = self.device_record.clone();
+        let now = now_ms();
+        record.updated_at = now;
+        record.expires_at = now + RECORD_TTL_MS;
+        record.hosted_services = self.hosted_services_rx.borrow().clone();
         let tags = vec![
             vec!["t".to_string(), DEFAULT_RECORD_TAG.to_string()],
             vec!["type".to_string(), "device".to_string()],
-            vec!["role".to_string(), self.device_record.role.clone()],
+            vec!["role".to_string(), record.role.clone()],
         ];
-        let content = self.device_record.to_json();
+        let content = record.to_json();
         let unsigned = nostr::build_unsigned_event(
             &self.nostr_pubkey,
             DEFAULT_RECORD_KIND,
@@ -289,6 +330,10 @@ pub fn default_record_tag() -> String {
 
 fn default_service_version() -> String {
     service_version()
+}
+
+fn default_device_kind() -> String {
+    "service".to_string()
 }
 
 fn default_release_channel() -> String {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -424,6 +424,7 @@ mod tests {
 
         let json = record.to_json();
         assert!(json.contains("\"deviceKind\":\"service\""));
+        assert!(json.contains("\"relays\":[\"ws://gateway.example:7447\"]"));
         assert!(json.contains("\"hostedServices\":["));
         assert!(json.contains("\"service\":\"nvr\""));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -472,6 +472,7 @@ struct HostedNvrService {
     record: discovery::HostedServiceRecord,
     api_base_url: String,
     health: Value,
+    config: HostedNvrConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1759,6 +1760,7 @@ async fn load_hosted_nvr_service(client: &HttpClient, gateway_pk: &str) -> Optio
                         },
                         api_base_url,
                         health,
+                        config: cfg.clone(),
                     });
                 }
             } else {
@@ -1805,6 +1807,7 @@ async fn load_hosted_nvr_service(client: &HttpClient, gateway_pk: &str) -> Optio
             },
             api_base_url,
             health: json!({}),
+            config: cfg.clone(),
         });
     }
     None
@@ -2600,7 +2603,7 @@ fn build_gateway_managed_launch_status_payload(
         kind: "gateway_managed_launch_status".to_string(),
         request_id: req.request_id.clone(),
         status: status.to_string(),
-        to_device_pk: req.to_device_pk.clone(),
+        to_device_pk: req.device_pk.clone(),
         gateway_pk: gateway_pk.to_string(),
         identity_id: req.identity_id.clone(),
         device_pk: req.device_pk.clone(),
@@ -2627,7 +2630,7 @@ fn build_gateway_signal_status_payload(
         kind: "gateway_signal_status".to_string(),
         request_id: req.request_id.clone(),
         status: status.to_string(),
-        to_device_pk: req.to_device_pk.clone(),
+        to_device_pk: req.device_pk.clone(),
         gateway_pk: gateway_pk.to_string(),
         identity_id: req.identity_id.clone(),
         device_pk: req.device_pk.clone(),
@@ -2672,12 +2675,33 @@ fn service_sources_from_health(health: &Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn service_sources_from_config(cameras: &[Value]) -> Vec<String> {
+    cameras
+        .iter()
+        .filter_map(|entry| {
+            entry.get("source_id")
+                .and_then(|v| v.as_str())
+                .or_else(|| entry.get("sourceId").and_then(|v| v.as_str()))
+                .map(|v| v.trim().to_string())
+        })
+        .filter(|entry| !entry.is_empty())
+        .collect()
+}
+
 fn build_managed_service_display(
     hosted: &HostedNvrService,
     req: &GatewayManagedLaunchRequest,
     stun_servers: &[String],
     turn_servers: &[String],
 ) -> Value {
+    let sources = {
+        let live = service_sources_from_health(&hosted.health);
+        if live.is_empty() {
+            service_sources_from_config(&hosted.config.cameras)
+        } else {
+            live
+        }
+    };
     json!({
         "gatewayPk": hosted.record.host_gateway_pk.clone(),
         "servicePk": hosted.record.device_pk.clone(),
@@ -2686,7 +2710,7 @@ fn build_managed_service_display(
         "service": hosted.record.service.clone(),
         "status": hosted.record.status.clone(),
         "cameraCount": hosted.record.camera_count,
-        "sources": service_sources_from_health(&hosted.health),
+        "sources": sources,
         "cameras": hosted.health.get("cameras").cloned().unwrap_or_else(|| json!([])),
         "sourceRuntime": hosted.health.get("sourceRuntime").cloned().unwrap_or_else(|| json!([])),
         "configuredSources": hosted.health.get("configuredSources").cloned().unwrap_or_else(|| json!(hosted.record.camera_count)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -911,25 +911,18 @@ async fn main() -> Result<()> {
         load_hosted_services_snapshot(&http_client, &cfg.nostr_pubkey).await;
     let (swarm_tx, swarm_rx) = watch::channel(cfg.swarm_endpoint.clone());
     let (metrics_tx, metrics_rx) = watch::channel(discovery::GatewayMetrics::default());
-    let (hosted_services_tx, hosted_services_rx) = watch::channel(hosted_services_initial);
+    let (hosted_services_tx, hosted_services_rx) = watch::channel(hosted_services_initial.clone());
     let relay_req = discovery::relay_req_json();
     let (inbound_tx, mut inbound_rx) = mpsc::unbounded_channel::<String>();
     let (local_in_tx, mut local_in_rx) = mpsc::unbounded_channel::<Value>();
     let store = Arc::new(Mutex::new(SwarmStoreMap::new()));
     let (udp_in_tx, mut udp_in_rx) = mpsc::unbounded_channel::<transport::UdpInbound>();
-    if !cfg.nostr_pubkey.is_empty() && !cfg.nostr_sk_hex.is_empty() {
-        if let Ok(ev) =
-            build_device_record_event(&cfg.nostr_pubkey, &cfg.nostr_sk_hex, &device_record)
-        {
-            let _ = store.lock().await.put_record_all(&zones, &ev);
-        }
-    }
     // === Network services: relay, discovery publisher, UDP transport ===
     let relay_pool =
         relay::RelayPool::new(cfg.nostr_relays.clone(), relay_req, Some(inbound_tx)).await;
     let discovery_client = discovery::DiscoveryClient::new(
         relay_pool.clone(),
-        device_record,
+        device_record.clone(),
         cfg.nostr_pubkey.clone(),
         cfg.nostr_sk_hex.clone(),
         Duration::from_secs(cfg.nostr_publish_interval_secs),
@@ -1217,6 +1210,13 @@ async fn main() -> Result<()> {
 
     let hosted_services_gateway_pk = cfg.nostr_pubkey.clone();
     let hosted_services_client = http_client.clone();
+    let hosted_services_store = store.clone();
+    let hosted_services_relay_pool = relay_pool.clone();
+    let hosted_services_local_relay = local_relay.clone();
+    let hosted_services_zones = zones.clone();
+    let hosted_services_device_record = device_record.clone();
+    let hosted_services_self_pk = cfg.nostr_pubkey.clone();
+    let hosted_services_self_sk = cfg.nostr_sk_hex.clone();
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(Duration::from_secs(10));
         loop {
@@ -1224,9 +1224,20 @@ async fn main() -> Result<()> {
             let snapshot =
                 load_hosted_services_snapshot(&hosted_services_client, &hosted_services_gateway_pk)
                     .await;
-            if hosted_services_tx.send(snapshot).is_err() {
+            if hosted_services_tx.send(snapshot.clone()).is_err() {
                 break;
             }
+            publish_current_device_record(
+                &hosted_services_self_pk,
+                &hosted_services_self_sk,
+                &hosted_services_device_record,
+                &snapshot,
+                &hosted_services_zones,
+                &hosted_services_store,
+                &hosted_services_relay_pool,
+                &hosted_services_local_relay,
+            )
+            .await;
         }
     });
 
@@ -2112,7 +2123,7 @@ fn execute_nvr_install_request(
         c.arg("bash");
         c
     } else {
-        let mut c = Command::new("bash");
+        let c = Command::new("bash");
         c
     };
 
@@ -3770,6 +3781,36 @@ fn build_device_record_event(
         util::now_unix_seconds(),
     );
     nostr::sign_event(&unsigned, sk_hex)
+}
+
+async fn publish_current_device_record(
+    pubkey: &str,
+    sk_hex: &str,
+    base_record: &discovery::SwarmDeviceRecord,
+    hosted_services: &[discovery::HostedServiceRecord],
+    zones: &[String],
+    store: &Arc<Mutex<SwarmStoreMap>>,
+    relay_pool: &relay::RelayPool,
+    local_relay: &Option<local_relay::LocalRelayHandle>,
+) {
+    if pubkey.trim().is_empty() || sk_hex.trim().is_empty() {
+        return;
+    }
+    let mut record = base_record.clone();
+    record.hosted_services = hosted_services.to_vec();
+    let Ok(record_ev) = build_device_record_event(pubkey, sk_hex, &record) else {
+        return;
+    };
+    {
+        let mut guard = store.lock().await;
+        let _ = guard.put_record_all(zones, &record_ev);
+    }
+    relay_pool.broadcast(&nostr::frame_event(&record_ev));
+    if let Some(local) = local_relay.as_ref() {
+        if let Ok(val) = serde_json::to_value(&record_ev) {
+            local.publish_event(val).await;
+        }
+    }
 }
 
 fn build_dht_record_event(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,15 @@ mod transport;
 mod util;
 
 use crate::swarm_store::{RecordType, SwarmStoreMap};
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::{ArgAction, Parser};
 use futures_util::{SinkExt, StreamExt};
 use rand::RngCore;
+use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::Command;
@@ -305,6 +307,193 @@ struct GatewayZoneSyncStatusPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<String>,
     ts: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GatewayManagedLaunchRequest {
+    #[serde(rename = "requestId", default)]
+    request_id: String,
+    #[serde(rename = "toDevicePk", default)]
+    to_device_pk: String,
+    #[serde(rename = "identityId", default)]
+    identity_id: String,
+    #[serde(rename = "devicePk", default)]
+    device_pk: String,
+    #[serde(rename = "servicePk", default)]
+    service_pk: String,
+    #[serde(default)]
+    service: String,
+    #[serde(default)]
+    capability: String,
+    #[serde(rename = "launchNonce", default)]
+    launch_nonce: String,
+    #[serde(default)]
+    zone: String,
+    #[serde(rename = "appRepo", default)]
+    app_repo: String,
+    #[serde(default)]
+    display: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GatewayManagedLaunchStatusPayload {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(rename = "requestId")]
+    request_id: String,
+    status: String,
+    #[serde(rename = "toDevicePk")]
+    to_device_pk: String,
+    #[serde(rename = "gatewayPk")]
+    gateway_pk: String,
+    #[serde(rename = "identityId")]
+    identity_id: String,
+    #[serde(rename = "devicePk")]
+    device_pk: String,
+    #[serde(rename = "servicePk")]
+    service_pk: String,
+    service: String,
+    capability: String,
+    #[serde(rename = "launchToken", skip_serializing_if = "Option::is_none")]
+    launch_token: Option<String>,
+    #[serde(rename = "expiresAt", skip_serializing_if = "Option::is_none")]
+    expires_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    display: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    ts: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GatewaySignalRequest {
+    #[serde(rename = "requestId", default)]
+    request_id: String,
+    #[serde(rename = "toDevicePk", default)]
+    to_device_pk: String,
+    #[serde(rename = "identityId", default)]
+    identity_id: String,
+    #[serde(rename = "devicePk", default)]
+    device_pk: String,
+    #[serde(rename = "servicePk", default)]
+    service_pk: String,
+    #[serde(default)]
+    service: String,
+    #[serde(rename = "signalType", default)]
+    signal_type: String,
+    #[serde(default)]
+    payload: Value,
+    #[serde(rename = "launchToken", default)]
+    launch_token: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GatewaySignalStatusPayload {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(rename = "requestId")]
+    request_id: String,
+    status: String,
+    #[serde(rename = "toDevicePk")]
+    to_device_pk: String,
+    #[serde(rename = "gatewayPk")]
+    gateway_pk: String,
+    #[serde(rename = "identityId")]
+    identity_id: String,
+    #[serde(rename = "devicePk")]
+    device_pk: String,
+    #[serde(rename = "servicePk")]
+    service_pk: String,
+    service: String,
+    #[serde(rename = "signalType")]
+    signal_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    ts: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct GatewaySignalPayload {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(rename = "requestId")]
+    request_id: String,
+    #[serde(rename = "gatewayPk")]
+    gateway_pk: String,
+    #[serde(rename = "identityId")]
+    identity_id: String,
+    #[serde(rename = "devicePk")]
+    device_pk: String,
+    #[serde(rename = "servicePk")]
+    service_pk: String,
+    service: String,
+    #[serde(rename = "signalType")]
+    signal_type: String,
+    payload: Value,
+    ts: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct HostedNvrConfig {
+    #[serde(default)]
+    service_version: String,
+    #[serde(default)]
+    nostr_pubkey: String,
+    #[serde(default)]
+    device_label: String,
+    #[serde(default)]
+    cameras: Vec<Value>,
+    #[serde(default)]
+    api: HostedNvrApiConfig,
+    #[serde(default)]
+    gateway: HostedNvrGatewayConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct HostedNvrApiConfig {
+    #[serde(default)]
+    bind: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct HostedNvrGatewayConfig {
+    #[serde(default, rename = "host_gateway_pk")]
+    host_gateway_pk: String,
+    #[serde(default, rename = "hostGatewayPk")]
+    host_gateway_pk_camel: String,
+}
+
+#[derive(Debug, Clone)]
+struct HostedNvrService {
+    record: discovery::HostedServiceRecord,
+    api_base_url: String,
+    health: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ManagedLaunchTokenPayload {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(rename = "gatewayPk")]
+    gateway_pk: String,
+    #[serde(rename = "servicePk")]
+    service_pk: String,
+    service: String,
+    #[serde(rename = "identityId")]
+    identity_id: String,
+    #[serde(rename = "devicePk")]
+    device_pk: String,
+    capability: String,
+    #[serde(rename = "launchNonce")]
+    launch_nonce: String,
+    #[serde(rename = "issuedAt")]
+    issued_at: u64,
+    #[serde(rename = "expiresAt")]
+    expires_at: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -714,8 +903,15 @@ async fn main() -> Result<()> {
         cfg.release_branch.trim(),
     );
 
+    let http_client = HttpClient::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_else(|_| HttpClient::new());
+    let hosted_services_initial =
+        load_hosted_services_snapshot(&http_client, &cfg.nostr_pubkey).await;
     let (swarm_tx, swarm_rx) = watch::channel(cfg.swarm_endpoint.clone());
     let (metrics_tx, metrics_rx) = watch::channel(discovery::GatewayMetrics::default());
+    let (hosted_services_tx, hosted_services_rx) = watch::channel(hosted_services_initial);
     let relay_req = discovery::relay_req_json();
     let (inbound_tx, mut inbound_rx) = mpsc::unbounded_channel::<String>();
     let (local_in_tx, mut local_in_rx) = mpsc::unbounded_channel::<Value>();
@@ -740,6 +936,7 @@ async fn main() -> Result<()> {
         zones.clone(),
         swarm_rx,
         metrics_rx,
+        hosted_services_rx,
     );
     tokio::spawn(async move {
         if let Err(err) = discovery_client.run().await {
@@ -1007,6 +1204,9 @@ async fn main() -> Result<()> {
         seen_max: 4096,
         remote_service_install_enabled: cfg.remote_service_install_enabled,
         remote_service_install_timeout_secs: cfg.remote_service_install_timeout_secs.max(60),
+        http_client: http_client.clone(),
+        stun_servers: cfg.stun_servers.clone(),
+        turn_servers: cfg.turn_servers.clone(),
         authorized_control_device_pks: cfg
             .authorized_control_device_pks
             .iter()
@@ -1014,6 +1214,21 @@ async fn main() -> Result<()> {
             .filter(|v| !v.is_empty())
             .collect(),
     };
+
+    let hosted_services_gateway_pk = cfg.nostr_pubkey.clone();
+    let hosted_services_client = http_client.clone();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_secs(10));
+        loop {
+            ticker.tick().await;
+            let snapshot =
+                load_hosted_services_snapshot(&hosted_services_client, &hosted_services_gateway_pk)
+                    .await;
+            if hosted_services_tx.send(snapshot).is_err() {
+                break;
+            }
+        }
+    });
 
     let ctx_nostr = inbound_ctx.clone();
     tokio::spawn(async move {
@@ -1400,6 +1615,253 @@ fn normalize_gateway_zone_sync_request(req: &mut GatewayZoneSyncRequest) {
     req.extra_zone_keys = dedup_valid_zone_keys(&req.extra_zone_keys, 64);
 }
 
+fn normalize_gateway_managed_launch_request(req: &mut GatewayManagedLaunchRequest) {
+    req.request_id = trim_nonempty(&req.request_id);
+    if req.request_id.is_empty() {
+        req.request_id = make_install_request_id();
+    }
+    req.to_device_pk = trim_nonempty(&req.to_device_pk);
+    req.identity_id = trim_nonempty(&req.identity_id);
+    req.device_pk = trim_nonempty(&req.device_pk);
+    req.service_pk = trim_nonempty(&req.service_pk);
+    req.service = trim_nonempty(&req.service).to_ascii_lowercase();
+    req.capability = trim_nonempty(&req.capability).to_ascii_lowercase();
+    req.launch_nonce = trim_nonempty(&req.launch_nonce);
+    req.zone = trim_nonempty(&req.zone);
+    req.app_repo = trim_nonempty(&req.app_repo);
+}
+
+fn normalize_gateway_signal_request(req: &mut GatewaySignalRequest) {
+    req.request_id = trim_nonempty(&req.request_id);
+    if req.request_id.is_empty() {
+        req.request_id = make_install_request_id();
+    }
+    req.to_device_pk = trim_nonempty(&req.to_device_pk);
+    req.identity_id = trim_nonempty(&req.identity_id);
+    req.device_pk = trim_nonempty(&req.device_pk);
+    req.service_pk = trim_nonempty(&req.service_pk);
+    req.service = trim_nonempty(&req.service).to_ascii_lowercase();
+    req.signal_type = trim_nonempty(&req.signal_type).to_ascii_lowercase();
+    req.launch_token = trim_nonempty(&req.launch_token);
+}
+
+fn nvr_config_candidates() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    out.push(PathBuf::from("/etc/constitute-nvr/config.json"));
+    if let Ok(local_appdata) = std::env::var("LOCALAPPDATA") {
+        out.push(
+            PathBuf::from(local_appdata)
+                .join("Constitute")
+                .join("nvr")
+                .join("config.json"),
+        );
+    }
+    out
+}
+
+fn nvr_local_base_url(bind: &str) -> Option<String> {
+    let mut raw = bind.trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    if !raw.contains(':') {
+        raw = format!("127.0.0.1:{raw}");
+    }
+    let addr: SocketAddr = raw.parse().ok()?;
+    Some(format!("http://127.0.0.1:{}", addr.port()))
+}
+
+async fn load_hosted_nvr_service(client: &HttpClient, gateway_pk: &str) -> Option<HostedNvrService> {
+    for path in nvr_config_candidates() {
+        let raw = match fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(_) => continue,
+        };
+        let cfg: HostedNvrConfig = match serde_json::from_str(&raw) {
+            Ok(cfg) => cfg,
+            Err(_) => continue,
+        };
+        let service_pk = cfg.nostr_pubkey.trim().to_string();
+        if service_pk.is_empty() {
+            continue;
+        }
+        let api_base_url = match nvr_local_base_url(&cfg.api.bind) {
+            Some(url) => url,
+            None => continue,
+        };
+
+        let now = util::now_unix_seconds() * 1000;
+        let mut status = "configured".to_string();
+        let mut camera_count = cfg.cameras.len() as u64;
+        if let Ok(resp) = client
+            .get(format!("{api_base_url}/health"))
+            .timeout(Duration::from_secs(3))
+            .send()
+            .await
+        {
+            if resp.status().is_success() {
+                if let Ok(body) = resp.json::<Value>().await {
+                    status = "online".to_string();
+                    let health = body.clone();
+                    camera_count = body
+                        .get("configuredSources")
+                        .and_then(|v| v.as_u64())
+                        .or_else(|| {
+                            body.get("sources")
+                                .and_then(|v| v.as_array())
+                                .map(|v| v.len() as u64)
+                        })
+                        .unwrap_or(camera_count);
+                    return Some(HostedNvrService {
+                        record: discovery::HostedServiceRecord {
+                            device_pk: service_pk,
+                            device_label: if cfg.device_label.trim().is_empty() {
+                                "Constitute NVR".to_string()
+                            } else {
+                                cfg.device_label.trim().to_string()
+                            },
+                            device_kind: "service".to_string(),
+                            service: "nvr".to_string(),
+                            host_gateway_pk: {
+                                let explicit = cfg.gateway.host_gateway_pk.trim();
+                                if explicit.is_empty() {
+                                    let alt = cfg.gateway.host_gateway_pk_camel.trim();
+                                    if alt.is_empty() {
+                                        gateway_pk.trim()
+                                    } else {
+                                        alt
+                                    }
+                                } else {
+                                    explicit
+                                }
+                            }
+                            .to_string(),
+                            service_version: if cfg.service_version.trim().is_empty() {
+                                env!("CARGO_PKG_VERSION").to_string()
+                            } else {
+                                cfg.service_version.trim().to_string()
+                            },
+                            updated_at: now,
+                            freshness_ms: 0,
+                            status,
+                            camera_count,
+                        },
+                        api_base_url,
+                        health,
+                    });
+                }
+            } else {
+                status = "offline".to_string();
+            }
+        } else {
+            status = "offline".to_string();
+        }
+        let host_gateway_pk = {
+            let explicit = cfg.gateway.host_gateway_pk.trim();
+            if explicit.is_empty() {
+                let alt = cfg.gateway.host_gateway_pk_camel.trim();
+                if alt.is_empty() {
+                    gateway_pk.trim()
+                } else {
+                    alt
+                }
+            } else {
+                explicit
+            }
+        }
+        .to_string();
+
+        return Some(HostedNvrService {
+            record: discovery::HostedServiceRecord {
+                device_pk: service_pk,
+                device_label: if cfg.device_label.trim().is_empty() {
+                    "Constitute NVR".to_string()
+                } else {
+                    cfg.device_label.trim().to_string()
+                },
+                device_kind: "service".to_string(),
+                service: "nvr".to_string(),
+                host_gateway_pk,
+                service_version: if cfg.service_version.trim().is_empty() {
+                    env!("CARGO_PKG_VERSION").to_string()
+                } else {
+                    cfg.service_version.trim().to_string()
+                },
+                updated_at: now,
+                freshness_ms: 0,
+                status,
+                camera_count,
+            },
+            api_base_url,
+            health: json!({}),
+        });
+    }
+    None
+}
+
+async fn load_hosted_services_snapshot(
+    client: &HttpClient,
+    gateway_pk: &str,
+) -> Vec<discovery::HostedServiceRecord> {
+    match load_hosted_nvr_service(client, gateway_pk).await {
+        Some(service) => vec![service.record],
+        None => Vec::new(),
+    }
+}
+
+fn capability_allowed_for_service(service: &str, capability: &str) -> bool {
+    matches!(
+        (service.trim(), capability.trim()),
+        ("nvr", "nvr.view") | ("nvr", "nvr.manage") | ("nvr", "gateway.launch_managed_app")
+    )
+}
+
+async fn is_requester_authorized_for_capability(
+    ctx: &InboundContext,
+    requester_pk: &str,
+    identity_id: &str,
+    service: &str,
+    capability: &str,
+) -> bool {
+    if !capability_allowed_for_service(service, capability) {
+        return false;
+    }
+    is_requester_authorized_for_service_install(ctx, requester_pk, identity_id).await
+}
+
+fn build_managed_launch_token(
+    pubkey: &str,
+    sk_hex: &str,
+    payload: &ManagedLaunchTokenPayload,
+) -> Result<String> {
+    let tags = vec![
+        vec!["t".to_string(), "constitute".to_string()],
+        vec!["type".to_string(), "managed_launch_token".to_string()],
+        vec!["service".to_string(), payload.service.clone()],
+        vec!["p".to_string(), payload.device_pk.clone()],
+        vec!["p".to_string(), payload.service_pk.clone()],
+    ];
+    let unsigned = nostr::build_unsigned_event(
+        pubkey,
+        27235,
+        tags,
+        serde_json::to_string(payload)?,
+        util::now_unix_seconds(),
+    );
+    let ev = nostr::sign_event(&unsigned, sk_hex)?;
+    Ok(serde_json::to_string(&ev)?)
+}
+
+fn parse_managed_launch_token(token: &str) -> Result<(nostr::NostrEvent, ManagedLaunchTokenPayload)> {
+    let ev: nostr::NostrEvent = serde_json::from_str(token).context("invalid launch token json")?;
+    if !nostr::verify_event(&ev)? {
+        return Err(anyhow!("invalid launch token signature"));
+    }
+    let payload: ManagedLaunchTokenPayload =
+        serde_json::from_str(&ev.content).context("invalid launch token payload")?;
+    Ok((ev, payload))
+}
+
 async fn publish_gateway_service_install_status(
     relay_pool: &relay::RelayPool,
     local_relay: &Option<local_relay::LocalRelayHandle>,
@@ -1427,6 +1889,69 @@ async fn publish_gateway_zone_sync_status(
     pubkey: &str,
     sk_hex: &str,
     payload: &GatewayZoneSyncStatusPayload,
+) -> Result<()> {
+    if pubkey.is_empty() || sk_hex.is_empty() {
+        return Ok(());
+    }
+    let value = serde_json::to_value(payload)?;
+    let ev = build_app_event(pubkey, sk_hex, &value)?;
+    relay_pool.broadcast(&nostr::frame_event(&ev));
+    if let Some(local) = local_relay.as_ref() {
+        if let Ok(val) = serde_json::to_value(ev) {
+            local.publish_event(val).await;
+        }
+    }
+    Ok(())
+}
+
+async fn publish_gateway_managed_launch_status(
+    relay_pool: &relay::RelayPool,
+    local_relay: &Option<local_relay::LocalRelayHandle>,
+    pubkey: &str,
+    sk_hex: &str,
+    payload: &GatewayManagedLaunchStatusPayload,
+) -> Result<()> {
+    if pubkey.is_empty() || sk_hex.is_empty() {
+        return Ok(());
+    }
+    let value = serde_json::to_value(payload)?;
+    let ev = build_app_event(pubkey, sk_hex, &value)?;
+    relay_pool.broadcast(&nostr::frame_event(&ev));
+    if let Some(local) = local_relay.as_ref() {
+        if let Ok(val) = serde_json::to_value(ev) {
+            local.publish_event(val).await;
+        }
+    }
+    Ok(())
+}
+
+async fn publish_gateway_signal_status(
+    relay_pool: &relay::RelayPool,
+    local_relay: &Option<local_relay::LocalRelayHandle>,
+    pubkey: &str,
+    sk_hex: &str,
+    payload: &GatewaySignalStatusPayload,
+) -> Result<()> {
+    if pubkey.is_empty() || sk_hex.is_empty() {
+        return Ok(());
+    }
+    let value = serde_json::to_value(payload)?;
+    let ev = build_app_event(pubkey, sk_hex, &value)?;
+    relay_pool.broadcast(&nostr::frame_event(&ev));
+    if let Some(local) = local_relay.as_ref() {
+        if let Ok(val) = serde_json::to_value(ev) {
+            local.publish_event(val).await;
+        }
+    }
+    Ok(())
+}
+
+async fn publish_gateway_signal(
+    relay_pool: &relay::RelayPool,
+    local_relay: &Option<local_relay::LocalRelayHandle>,
+    pubkey: &str,
+    sk_hex: &str,
+    payload: &GatewaySignalPayload,
 ) -> Result<()> {
     if pubkey.is_empty() || sk_hex.is_empty() {
         return Ok(());
@@ -2050,6 +2575,167 @@ fn build_gateway_zone_sync_status_payload(
     }
 }
 
+fn build_gateway_managed_launch_status_payload(
+    req: &GatewayManagedLaunchRequest,
+    gateway_pk: &str,
+    status: &str,
+    launch_token: Option<String>,
+    expires_at: Option<u64>,
+    display: Option<Value>,
+    reason: Option<String>,
+    detail: Option<String>,
+) -> GatewayManagedLaunchStatusPayload {
+    GatewayManagedLaunchStatusPayload {
+        kind: "gateway_managed_launch_status".to_string(),
+        request_id: req.request_id.clone(),
+        status: status.to_string(),
+        to_device_pk: req.to_device_pk.clone(),
+        gateway_pk: gateway_pk.to_string(),
+        identity_id: req.identity_id.clone(),
+        device_pk: req.device_pk.clone(),
+        service_pk: req.service_pk.clone(),
+        service: req.service.clone(),
+        capability: req.capability.clone(),
+        launch_token,
+        expires_at,
+        display,
+        reason,
+        detail,
+        ts: util::now_unix_seconds() * 1000,
+    }
+}
+
+fn build_gateway_signal_status_payload(
+    req: &GatewaySignalRequest,
+    gateway_pk: &str,
+    status: &str,
+    reason: Option<String>,
+    detail: Option<String>,
+) -> GatewaySignalStatusPayload {
+    GatewaySignalStatusPayload {
+        kind: "gateway_signal_status".to_string(),
+        request_id: req.request_id.clone(),
+        status: status.to_string(),
+        to_device_pk: req.to_device_pk.clone(),
+        gateway_pk: gateway_pk.to_string(),
+        identity_id: req.identity_id.clone(),
+        device_pk: req.device_pk.clone(),
+        service_pk: req.service_pk.clone(),
+        service: req.service.clone(),
+        signal_type: req.signal_type.clone(),
+        reason,
+        detail,
+        ts: util::now_unix_seconds() * 1000,
+    }
+}
+
+fn build_gateway_signal_payload(
+    req: &GatewaySignalRequest,
+    gateway_pk: &str,
+    payload: Value,
+) -> GatewaySignalPayload {
+    GatewaySignalPayload {
+        kind: "gateway_signal".to_string(),
+        request_id: req.request_id.clone(),
+        gateway_pk: gateway_pk.to_string(),
+        identity_id: req.identity_id.clone(),
+        device_pk: req.device_pk.clone(),
+        service_pk: req.service_pk.clone(),
+        service: req.service.clone(),
+        signal_type: req.signal_type.clone(),
+        payload,
+        ts: util::now_unix_seconds() * 1000,
+    }
+}
+
+fn service_sources_from_health(health: &Value) -> Vec<String> {
+    health
+        .get("sources")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|entry| entry.as_str().map(|v| v.trim().to_string()))
+                .filter(|entry| !entry.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn build_managed_service_display(
+    hosted: &HostedNvrService,
+    req: &GatewayManagedLaunchRequest,
+    stun_servers: &[String],
+    turn_servers: &[String],
+) -> Value {
+    json!({
+        "gatewayPk": hosted.record.host_gateway_pk.clone(),
+        "servicePk": hosted.record.device_pk.clone(),
+        "serviceLabel": hosted.record.device_label.clone(),
+        "serviceVersion": hosted.record.service_version.clone(),
+        "service": hosted.record.service.clone(),
+        "status": hosted.record.status.clone(),
+        "cameraCount": hosted.record.camera_count,
+        "sources": service_sources_from_health(&hosted.health),
+        "cameras": hosted.health.get("cameras").cloned().unwrap_or_else(|| json!([])),
+        "sourceRuntime": hosted.health.get("sourceRuntime").cloned().unwrap_or_else(|| json!([])),
+        "configuredSources": hosted.health.get("configuredSources").cloned().unwrap_or_else(|| json!(hosted.record.camera_count)),
+        "iceServers": {
+            "stun": stun_servers,
+            "turn": turn_servers,
+        },
+        "appRepo": req.app_repo.clone(),
+        "requestDisplay": req.display.clone(),
+    })
+}
+
+async fn load_target_hosted_service(
+    ctx: &InboundContext,
+    service_pk: &str,
+    service: &str,
+) -> Result<HostedNvrService> {
+    let service_slug = service.trim().to_ascii_lowercase();
+    if service_slug != "nvr" {
+        return Err(anyhow!("unsupported managed service"));
+    }
+    let hosted = load_hosted_nvr_service(&ctx.http_client, &ctx.self_pk)
+        .await
+        .ok_or_else(|| anyhow!("hosted nvr service not configured"))?;
+    if !service_pk.trim().is_empty() && hosted.record.device_pk.trim() != service_pk.trim() {
+        return Err(anyhow!("requested service pk does not match hosted service"));
+    }
+    Ok(hosted)
+}
+
+fn validate_managed_launch_token_for_request(
+    ctx: &InboundContext,
+    req: &GatewaySignalRequest,
+) -> Result<ManagedLaunchTokenPayload> {
+    let (event, token) = parse_managed_launch_token(&req.launch_token)?;
+    if event.pubkey.trim() != ctx.self_pk.trim() {
+        return Err(anyhow!("launch token not signed by this gateway"));
+    }
+    let now_ms = util::now_unix_seconds() * 1000;
+    if token.expires_at < now_ms {
+        return Err(anyhow!("launch token expired"));
+    }
+    if token.gateway_pk.trim() != ctx.self_pk.trim() {
+        return Err(anyhow!("launch token gateway mismatch"));
+    }
+    if token.identity_id.trim() != req.identity_id.trim() {
+        return Err(anyhow!("launch token identity mismatch"));
+    }
+    if token.device_pk.trim() != req.device_pk.trim() {
+        return Err(anyhow!("launch token device mismatch"));
+    }
+    if token.service_pk.trim() != req.service_pk.trim() {
+        return Err(anyhow!("launch token service mismatch"));
+    }
+    if token.service.trim() != req.service.trim() {
+        return Err(anyhow!("launch token service slug mismatch"));
+    }
+    Ok(token)
+}
+
 async fn handle_gateway_service_install_request(
     ctx: &InboundContext,
     nostr_ev: &nostr::NostrEvent,
@@ -2592,6 +3278,480 @@ async fn handle_gateway_zone_sync_request(
     }
 }
 
+async fn handle_gateway_managed_launch_request(
+    ctx: &InboundContext,
+    nostr_ev: &nostr::NostrEvent,
+    payload: &Value,
+) {
+    let mut req: GatewayManagedLaunchRequest = match serde_json::from_value(payload.clone()) {
+        Ok(req) => req,
+        Err(err) => {
+            warn!(error = %err, "invalid gateway_managed_launch_request payload");
+            return;
+        }
+    };
+    normalize_gateway_managed_launch_request(&mut req);
+
+    if req.to_device_pk != ctx.self_pk {
+        return;
+    }
+
+    if req.service.is_empty() {
+        req.service = "nvr".to_string();
+    }
+    if req.capability.is_empty() {
+        req.capability = "nvr.view".to_string();
+    }
+    if req.app_repo.is_empty() {
+        req.app_repo = "constitute-nvr-ui".to_string();
+    }
+
+    let requester_pk = nostr_ev.pubkey.trim().to_string();
+    if req.device_pk.is_empty() {
+        req.device_pk = requester_pk.clone();
+    }
+
+    let publish_status =
+        |status: &str,
+         launch_token: Option<String>,
+         expires_at: Option<u64>,
+         display: Option<Value>,
+         reason: Option<String>,
+         detail: Option<String>| {
+            build_gateway_managed_launch_status_payload(
+                &req,
+                &ctx.self_pk,
+                status,
+                launch_token,
+                expires_at,
+                display,
+                reason,
+                detail,
+            )
+        };
+
+    if requester_pk != req.device_pk {
+        let status = publish_status(
+            "rejected",
+            None,
+            None,
+            None,
+            Some("requester_device_mismatch".to_string()),
+            Some("requesting event pubkey does not match devicePk".to_string()),
+        );
+        let _ = publish_gateway_managed_launch_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
+        return;
+    }
+
+    let gateway_identity = ctx.gateway_identity_id.trim();
+    if gateway_identity.is_empty() || req.identity_id.trim() != gateway_identity {
+        let status = publish_status(
+            "rejected",
+            None,
+            None,
+            None,
+            Some("identity_mismatch".to_string()),
+            Some("request identity does not match gateway identity".to_string()),
+        );
+        let _ = publish_gateway_managed_launch_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
+        return;
+    }
+
+    if !is_requester_authorized_for_capability(
+        ctx,
+        &requester_pk,
+        &req.identity_id,
+        &req.service,
+        &req.capability,
+    )
+    .await
+    {
+        let status = publish_status(
+            "rejected",
+            None,
+            None,
+            None,
+            Some("unauthorized_requester".to_string()),
+            Some("requester is not authorized for requested capability".to_string()),
+        );
+        let _ = publish_gateway_managed_launch_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
+        return;
+    }
+
+    let hosted = match load_target_hosted_service(ctx, &req.service_pk, &req.service).await {
+        Ok(service) => service,
+        Err(err) => {
+            let status = publish_status(
+                "failed",
+                None,
+                None,
+                None,
+                Some("service_unavailable".to_string()),
+                Some(err.to_string()),
+            );
+            let _ = publish_gateway_managed_launch_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
+            return;
+        }
+    };
+
+    let mut launch_req = req.clone();
+    launch_req.service_pk = hosted.record.device_pk.clone();
+    if launch_req.launch_nonce.is_empty() {
+        launch_req.launch_nonce = random_hex(8);
+    }
+
+    let issued_at = util::now_unix_seconds() * 1000;
+    let expires_at = issued_at + 120_000;
+    let token_payload = ManagedLaunchTokenPayload {
+        kind: "managed_launch_token".to_string(),
+        gateway_pk: ctx.self_pk.clone(),
+        service_pk: launch_req.service_pk.clone(),
+        service: launch_req.service.clone(),
+        identity_id: launch_req.identity_id.clone(),
+        device_pk: launch_req.device_pk.clone(),
+        capability: launch_req.capability.clone(),
+        launch_nonce: launch_req.launch_nonce.clone(),
+        issued_at,
+        expires_at,
+    };
+    let launch_token = match build_managed_launch_token(&ctx.self_pk, &ctx.self_sk, &token_payload) {
+        Ok(token) => token,
+        Err(err) => {
+            let status = publish_status(
+                "failed",
+                None,
+                None,
+                None,
+                Some("token_build_failed".to_string()),
+                Some(err.to_string()),
+            );
+            let _ = publish_gateway_managed_launch_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
+            return;
+        }
+    };
+
+    let display = build_managed_service_display(
+        &hosted,
+        &launch_req,
+        &ctx.stun_servers,
+        &ctx.turn_servers,
+    );
+    let status = build_gateway_managed_launch_status_payload(
+        &launch_req,
+        &ctx.self_pk,
+        "complete",
+        Some(launch_token),
+        Some(expires_at),
+        Some(display),
+        None,
+        None,
+    );
+    let _ = publish_gateway_managed_launch_status(
+        &ctx.relay_pool,
+        &ctx.local_relay,
+        &ctx.self_pk,
+        &ctx.self_sk,
+        &status,
+    )
+    .await;
+}
+
+async fn handle_gateway_signal_request(
+    ctx: &InboundContext,
+    nostr_ev: &nostr::NostrEvent,
+    payload: &Value,
+) {
+    let mut req: GatewaySignalRequest = match serde_json::from_value(payload.clone()) {
+        Ok(req) => req,
+        Err(err) => {
+            warn!(error = %err, "invalid gateway_signal_request payload");
+            return;
+        }
+    };
+    normalize_gateway_signal_request(&mut req);
+
+    if req.to_device_pk != ctx.self_pk {
+        return;
+    }
+
+    if req.service.is_empty() {
+        req.service = "nvr".to_string();
+    }
+    let requester_pk = nostr_ev.pubkey.trim().to_string();
+    if req.device_pk.is_empty() {
+        req.device_pk = requester_pk.clone();
+    }
+
+    let publish_status = |status: &str, reason: Option<String>, detail: Option<String>| {
+        build_gateway_signal_status_payload(&req, &ctx.self_pk, status, reason, detail)
+    };
+
+    if requester_pk != req.device_pk {
+        let status = publish_status(
+            "rejected",
+            Some("requester_device_mismatch".to_string()),
+            Some("requesting event pubkey does not match devicePk".to_string()),
+        );
+        let _ = publish_gateway_signal_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
+        return;
+    }
+
+    let token = match validate_managed_launch_token_for_request(ctx, &req) {
+        Ok(token) => token,
+        Err(err) => {
+            let status = publish_status(
+                "rejected",
+                Some("invalid_launch_token".to_string()),
+                Some(err.to_string()),
+            );
+            let _ = publish_gateway_signal_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
+            return;
+        }
+    };
+
+    if !is_requester_authorized_for_capability(
+        ctx,
+        &requester_pk,
+        &req.identity_id,
+        &req.service,
+        &token.capability,
+    )
+    .await
+    {
+        let status = publish_status(
+            "rejected",
+            Some("unauthorized_requester".to_string()),
+            Some("requester is not authorized for launch capability".to_string()),
+        );
+        let _ = publish_gateway_signal_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
+        return;
+    }
+
+    let hosted = match load_target_hosted_service(ctx, &req.service_pk, &req.service).await {
+        Ok(service) => service,
+        Err(err) => {
+            let status = publish_status(
+                "failed",
+                Some("service_unavailable".to_string()),
+                Some(err.to_string()),
+            );
+            let _ = publish_gateway_signal_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
+            return;
+        }
+    };
+
+    let accepted = publish_status("accepted", None, None);
+    let _ = publish_gateway_signal_status(
+        &ctx.relay_pool,
+        &ctx.local_relay,
+        &ctx.self_pk,
+        &ctx.self_sk,
+        &accepted,
+    )
+    .await;
+
+    let url = match req.signal_type.as_str() {
+        "offer" => format!("{}/managed/offer", hosted.api_base_url),
+        "session_close" => format!("{}/managed/close", hosted.api_base_url),
+        _ => {
+            let status = publish_status(
+                "rejected",
+                Some("unsupported_signal".to_string()),
+                Some("only offer and session_close are supported".to_string()),
+            );
+            let _ = publish_gateway_signal_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
+            return;
+        }
+    };
+
+    let request_body = if req.signal_type == "offer" {
+        json!({
+            "launchToken": req.launch_token.clone(),
+            "offer": req.payload.clone(),
+            "iceServers": {
+                "stun": ctx.stun_servers.clone(),
+                "turn": ctx.turn_servers.clone(),
+            }
+        })
+    } else {
+        json!({
+            "launchToken": req.launch_token.clone(),
+            "payload": req.payload.clone(),
+        })
+    };
+
+    let response = ctx.http_client.post(&url).json(&request_body).send().await;
+    let response = match response {
+        Ok(resp) => resp,
+        Err(err) => {
+            let status = publish_status(
+                "failed",
+                Some("service_signal_failed".to_string()),
+                Some(err.to_string()),
+            );
+            let _ = publish_gateway_signal_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
+            return;
+        }
+    };
+
+    let response_status = response.status();
+    if !response_status.is_success() {
+        let detail = match response.text().await {
+            Ok(text) if !text.trim().is_empty() => text,
+            _ => format!("status {}", response_status),
+        };
+        let status = publish_status(
+            "failed",
+            Some("service_signal_rejected".to_string()),
+            Some(detail),
+        );
+        let _ = publish_gateway_signal_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
+        return;
+    }
+
+    if req.signal_type == "offer" {
+        let body: Value = match response.json().await {
+            Ok(body) => body,
+            Err(err) => {
+                let status = publish_status(
+                    "failed",
+                    Some("invalid_service_signal_response".to_string()),
+                    Some(err.to_string()),
+                );
+                let _ = publish_gateway_signal_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
+                return;
+            }
+        };
+        let signal_type = body
+            .get("signalType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("answer")
+            .trim()
+            .to_ascii_lowercase();
+        let payload_value = if body.is_object() {
+            body.clone()
+        } else {
+            body.get("payload")
+                .cloned()
+                .or_else(|| body.get("answer").cloned())
+                .unwrap_or_else(|| json!({}))
+        };
+        let signal = GatewaySignalPayload {
+            signal_type,
+            ..build_gateway_signal_payload(&req, &ctx.self_pk, payload_value)
+        };
+        let _ = publish_gateway_signal(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &signal,
+        )
+        .await;
+    }
+
+    let status = publish_status("complete", None, None);
+    let _ = publish_gateway_signal_status(
+        &ctx.relay_pool,
+        &ctx.local_relay,
+        &ctx.self_pk,
+        &ctx.self_sk,
+        &status,
+    )
+    .await;
+}
+
 fn build_device_record_event(
     pubkey: &str,
     sk_hex: &str,
@@ -2784,6 +3944,11 @@ fn is_mesh_passthrough_kind(kind: &str) -> bool {
             | "gateway_service_install_status"
             | "gateway_zone_sync_request"
             | "gateway_zone_sync_status"
+            | "gateway_managed_launch_request"
+            | "gateway_managed_launch_status"
+            | "gateway_signal_request"
+            | "gateway_signal_status"
+            | "gateway_signal"
     )
 }
 
@@ -2889,6 +4054,9 @@ struct InboundContext {
     seen_max: usize,
     remote_service_install_enabled: bool,
     remote_service_install_timeout_secs: u64,
+    http_client: HttpClient,
+    stun_servers: Vec<String>,
+    turn_servers: Vec<String>,
     authorized_control_device_pks: HashSet<String>,
 }
 
@@ -3303,6 +4471,16 @@ async fn process_inbound_event(
 
         if kind == "gateway_zone_sync_request" {
             handle_gateway_zone_sync_request(&ctx, &nostr_ev, &payload).await;
+            return;
+        }
+
+        if kind == "gateway_managed_launch_request" {
+            handle_gateway_managed_launch_request(&ctx, &nostr_ev, &payload).await;
+            return;
+        }
+
+        if kind == "gateway_signal_request" {
+            handle_gateway_signal_request(&ctx, &nostr_ev, &payload).await;
             return;
         }
 
@@ -4281,6 +5459,9 @@ mod tests {
             pair_code_hash: String::new(),
             remote_service_install_enabled: false,
             remote_service_install_timeout_secs: 300,
+            http_client: HttpClient::new(),
+            stun_servers: Vec::new(),
+            turn_servers: Vec::new(),
             authorized_control_device_pks: HashSet::new(),
         };
 
@@ -4466,6 +5647,9 @@ mod tests {
             pair_code_hash: String::new(),
             remote_service_install_enabled: false,
             remote_service_install_timeout_secs: 300,
+            http_client: HttpClient::new(),
+            stun_servers: Vec::new(),
+            turn_servers: Vec::new(),
             authorized_control_device_pks: HashSet::new(),
         };
 
@@ -4608,6 +5792,9 @@ mod tests {
             pair_code_hash: String::new(),
             remote_service_install_enabled: false,
             remote_service_install_timeout_secs: 300,
+            http_client: HttpClient::new(),
+            stun_servers: Vec::new(),
+            turn_servers: Vec::new(),
             authorized_control_device_pks: HashSet::new(),
         };
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -17,6 +17,8 @@ fn discovery_envelope_shape() {
     let (_tx, rx) = tokio::sync::watch::channel("".to_string());
     let (_metrics_tx, metrics_rx) =
         tokio::sync::watch::channel(constitute_gateway::discovery::GatewayMetrics::default());
+    let (_hosted_tx, hosted_rx) =
+        tokio::sync::watch::channel(Vec::<constitute_gateway::discovery::HostedServiceRecord>::new());
     let client = constitute_gateway::discovery::DiscoveryClient::new(
         constitute_gateway::relay::RelayPool::empty(),
         record,
@@ -26,6 +28,7 @@ fn discovery_envelope_shape() {
         vec!["zonekey".to_string()],
         rx,
         metrics_rx,
+        hosted_rx,
     );
     let json = client.test_envelope_json();
     let v: Value = serde_json::from_str(&json).expect("valid json");
@@ -74,6 +77,8 @@ fn zone_presence_envelope_shape() {
     let (_tx, rx) = tokio::sync::watch::channel("".to_string());
     let (_metrics_tx, metrics_rx) =
         tokio::sync::watch::channel(constitute_gateway::discovery::GatewayMetrics::default());
+    let (_hosted_tx, hosted_rx) =
+        tokio::sync::watch::channel(Vec::<constitute_gateway::discovery::HostedServiceRecord>::new());
     let client = constitute_gateway::discovery::DiscoveryClient::new(
         constitute_gateway::relay::RelayPool::empty(),
         record,
@@ -83,6 +88,7 @@ fn zone_presence_envelope_shape() {
         vec!["zonekey".to_string()],
         rx,
         metrics_rx,
+        hosted_rx,
     );
     let json = client.test_zone_presence_json("zonekey");
     let v: Value = serde_json::from_str(&json).expect("valid json");


### PR DESCRIPTION
## Summary
- add gateway-managed launch authorization and signaling for hosted NVR services
- publish service-backed device and hosted service inventory metadata in discovery records
- expose STUN/TURN hints and managed launch display payloads for Pages-native app surfaces

## Testing
- cargo test --quiet

Closes #31
