### PR TITLE
refactor(gateway): align browser surface contracts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,7 +10,8 @@ It is not the permanent UI container for first-party apps, and it is not a paral
 
 ## Alignment With Other Repos
 The active contract slice aligns with:
-- `constitute` for management shell and launch
+- `constitute-account` for browser identity/session/grant authority and shared runtime
+- `constitute-gateway-ui` for gateway-specific management UX
 - `constitute-nvr` for hosted service inventory and live preview signaling
 - `constitute-nvr-ui` for managed app surface bootstrap
 
@@ -101,6 +102,10 @@ Canonical flow:
 5. browser app surface uses gateway-mediated signaling to establish WebRTC with the hosted service
 6. hosted service validates the gateway-issued authorization before admitting the session
 
+Direct app entry is primary. The gateway may participate after the app has attached to account/runtime authority; the user should not need to visit account manually before using a first-party app.
+
+Current launch authorization is a transitional short-lived capability. The target direction is explicit cryptographic service capability state bound to identity, device, gateway, service, scope, expiry, nonce/replay protection, and encrypted session material where confidentiality is required.
+
 ## WebRTC Direction
 Gateway is the signaling/control boundary for browser-safe direct paths:
 - same-LAN clients should win via ICE host candidates
@@ -108,6 +113,7 @@ Gateway is the signaling/control boundary for browser-safe direct paths:
 - hard-NAT fallback via TURN remains a later slice unless operator TURN is already available
 
 Gateway should not force all media through itself if a direct authorized browser-to-service session is available.
+Gateway should also not become the routine media projection or transcoding data path. NVR/media services own media projection; gateway owns admission, signaling, and orchestration.
 
 ## Zone and Overlay Direction
 - UDP gossip remains zone-scoped.
@@ -137,6 +143,39 @@ Active sprint direction:
 - short-lived launch authorization
 - capability-enforced managed service launch
 - gateway-mediated signaling without leaking long-lived browser secrets to app surfaces
+- explicit signed-versus-encrypted audit for launch, signaling, and session metadata
+
+## Planned Host-Capability Direction
+
+This is future host-capability direction, not the current active implementation slice.
+
+- gateway should converge toward orchestrating and projecting host capabilities rather than directly embodying every host concern
+- planned host-local capability services include:
+  - `constitute-security`
+  - `constitute-storage`
+- gateway should:
+  - authorize and coordinate capability use
+  - surface status and notifications
+  - project policy/result state upward to browser surfaces
+- gateway should not become the permanent implementation home for:
+  - firewall/security engines
+  - object-storage engines
+  - every host-level daemon concern
+
+### Current Browser UI Split
+- gateway-specific browser management lives in `constitute-gateway-ui`
+- gateway UI focuses on:
+  - host/service inventory
+  - network posture
+  - security posture
+  - deploy/update/runtime state
+  - hosted-service control
+
+### Planned Capability Leases
+- future workloads should consume explicit host-capability leases instead of embedding those systems directly
+- expected early lease targets:
+  - hostile camera-network policy from `constitute-security`
+  - durable encrypted object/archive allocation from `constitute-storage`
 
 ## Documentation Surface
 - `README.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@ This repo is the native gateway dependency for Constitute web clients. Contribut
 - Operational legibility
 
 ## Ground Rules
-- Keep protocol behavior aligned with `constitute` web repo semantics
+- Keep protocol behavior aligned with `constitute-account`, `constitute-gateway-ui`, and app-surface semantics
 - Prefer explicit, testable behavior over convenience abstractions
 - Avoid hidden side effects in transport and relay paths
-- Preserve backward compatibility unless a migration path is defined
+- Do not preserve stale aliases or compatibility shims during pre-prod convergence; update all in-repo callers together
 
 ## Branching and PR Workflow
 1. Keep changes scoped to one behavior theme per PR

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Constitute Gateway
 
-Native gateway service for Constitute. This repository provides the native dependency layer that browser clients and native services use for discovery bootstrap, relay bridging, and swarm-facing transport primitives.
+Native gateway service for Constitution browser surfaces. This repository provides the native dependency layer that `constitute-account`, `constitute-gateway-ui`, `constitute-nvr-ui`, and native workloads use for discovery bootstrap, relay bridging, and swarm-facing transport primitives.
 
 ## Scope
 - Nostr-based discovery bootstrap and zone presence publication
@@ -27,10 +27,10 @@ In progress:
 
 ## Installation
 Web workflow:
-- In `constitute` web, open `Settings > Appliances`
-- Use `Download Installer Utility`
+- Open `constitute-gateway-ui`
+- Use the gateway management surface to open install/update flows
 - Run the generated operator command
-- After pairing, use `Configure Zones` in web Appliances to sync identity zones and optional gateway-extra zones
+- After pairing, use gateway zone-sync controls in `constitute-gateway-ui` to sync identity zones and optional gateway-extra zones
 
 CLI and source-build workflow:
 - See [`docs/OPERATOR.md`](docs/OPERATOR.md)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -69,8 +69,7 @@ Baseline guidance:
 - Apply CPU quotas and restart policies for stability.
 
 ## Role Configuration
-- `node_role` is the primary runtime role config key (default: `gateway`).
-- Legacy `node_type` is accepted for backward compatibility.
+- `node_role` is the runtime role config key (default: `gateway`).
 - Role values are normalized to lowercase and must be ASCII `[a-z0-9_-]`.
 
 ## Mesh Transport Configuration

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -7,8 +7,8 @@ This document is the install and update reference for `constitute-gateway`.
 - Linux: `constitute-operator-linux-amd64.tar.gz`
 
 ## Web-Driven Install
-1. In `constitute` web, open `Settings > Appliances`.
-2. Click `Download Installer Utility`.
+1. Open `constitute-gateway-ui`.
+2. Open the target gateway row and use the installer / operator action.
 3. Run the generated command from the operator host.
 
 The generated command passes `--pair-identity` so the installer can prepare pairing material when needed.
@@ -50,7 +50,7 @@ Pairing code generation occurs only when all conditions are true:
 - Gateway is not already paired (`identity_id` is empty).
 - Existing pairing material is missing or invalid for the target identity.
 
-On generation, the installer prints the one-time code. Claim it in `Settings > Pairing > Add Device`.
+On generation, the installer prints the one-time code. Claim it in `constitute-account` under pairing/device approval.
 After approval, the gateway persists the resolved `identity_id` into encrypted keystore state and performs one controlled restart so the paired runtime state is applied cleanly.
 
 ## Advanced CLI Options

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,11 +1,12 @@
 # Gateway Protocol Contract
 
-This document defines the protocol contract for `constitute-gateway` and the expected convergence surface with the web repository.
+This document defines the protocol contract for `constitute-gateway` and the expected convergence surface with the first-party browser repos.
 
 ## Contract Status
 - Status: `active`
-- Scope: gateway runtime, web<->gateway app channel, managed service launch/signaling, gateway<->gateway transport
-- Compatibility rule: additive changes only unless a version gate is introduced and implemented on both gateway and web
+- Scope: gateway runtime, browser<->gateway app channel, managed service launch/signaling, gateway<->gateway transport
+- Browser-facing repos currently include `constitute-account`, `constitute-gateway-ui`, and `constitute-nvr-ui`.
+- Change rule: this pre-prod contract may break only when the active project contract moves all affected repos together.
 
 ## Canonical Terms
 - `devicePk`: Nostr public key that identifies a runtime node
@@ -16,6 +17,7 @@ This document defines the protocol contract for `constitute-gateway` and the exp
 - `service`: service slug for service-backed devices
 - `hostGatewayPk`: gateway device public key that hosts a service-backed device
 - `launchToken`: short-lived gateway-issued authorization for managed app launch/session setup
+- `serviceCapability`: planned explicit cryptographic service-access capability that may supersede launch-token-only admission semantics
 
 ## Node Roles
 The role vocabulary is shared across discovery and presence payloads:
@@ -95,7 +97,6 @@ App-channel events are Nostr events tagged with `['t', 'constitute']`.
 ### Request: Record Lookup
 Incoming types accepted by gateway:
 - `swarm_record_request`
-- `swarm_discovery_request` (compat alias)
 
 Fields:
 - `requestId` (optional)
@@ -103,7 +104,7 @@ Fields:
 - `zone` (optional)
 - `identityId` (optional)
 - `devicePk` (optional)
-- `want` (optional array: `identity`, `device`, `dht`; defaults depend on request type)
+- `want` (optional array: `identity`, `device`, `dht`)
 
 Gateway responses:
 - `swarm_identity_record`
@@ -148,7 +149,7 @@ Optional fields:
 - `authorizedDevicePks`
 - `swarmPeers`
 - `publicWsUrl`
-- `allowUnsignedHelloMvp`
+- `allowUnsignedDebugHello`
 - `reolink*` provisioning hints
 - `storageRoot`
 - `timeoutSecs`
@@ -194,6 +195,12 @@ Validation rules:
 - requesting device must hold the requested capability
 - launch token must be short-lived and service-scoped
 
+Planned convergence direction:
+- the launch token is a transitional short-lived bearer-style capability
+- future service access should be represented as an explicit cryptographic capability bound to identity, requesting device, gateway, service, scope, expiry, and nonce/replay protection
+- sensitive session material must be encrypted to intended principals/devices, not merely signed
+- direct first-party app entry should be able to resolve valid retained account/runtime capability state without requiring a manual account-app visit first
+
 ### Request: Managed Service Signaling
 Incoming type:
 - `gateway_signal_request`
@@ -209,7 +216,7 @@ Required fields:
 - `payload`
 - `launchToken`
 
-`signalType` values for MVP:
+Current `signalType` values:
 - `offer`
 - `answer`
 - `ice_candidate`
@@ -299,6 +306,10 @@ Runtime behavior:
 - Same-LAN host ICE candidates are preferred.
 - NAT-friendly server reflexive candidates are allowed.
 - Hard-NAT guaranteed fallback via TURN is not required for this iteration unless operator TURN is present.
+- WebRTC media is encrypted in transit through DTLS-SRTP.
+- Gateway should not become the routine media data path when direct authorized browser-to-service media can be established.
+- Media projection, transcoding, and recording remain workload concerns, not gateway protocol responsibilities.
+- Signed discovery, launch, or signaling records are not confidential unless their sensitive fields are encrypted.
 
 ## Validation and Security Invariants
 
@@ -343,6 +354,6 @@ The following are executed during convergence:
 - shared test vectors for accepted/rejected envelopes
 
 ## Versioning Policy
-- Keep this contract backward-compatible whenever possible.
-- For breaking changes, add an explicit version marker and dual-accept period.
-- Remove legacy aliases only after web and gateway both pass compatibility tests.
+- This pre-prod contract may break when the active project contract changes.
+- Do not keep stale aliases once all in-repo callers have moved.
+- Add explicit version markers when the protocol graduates beyond pre-prod convergence.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Project Roadmap Brief
 
-This brief captures execution order across `constitute-gateway`, `constitute`, `constitute-nvr`, and `constitute-nvr-ui`.
+This brief captures execution order across `constitute-gateway`, `constitute-account`, `constitute-gateway-ui`, `constitute-nvr`, and `constitute-nvr-ui`.
 
 ## Delivery Strategy
 1. Freeze cross-repo contracts for service-backed devices and managed app surfaces.
@@ -17,6 +17,7 @@ Rationale:
 - Gateway: discovery, app-channel bridge, zone-scoped UDP/DHT path, optional QUIC mesh path, and gateway zone-sync/install contracts implemented.
 - Managed-service launch/signaling: active implementation slice.
 - NVR: service install path exists; live preview and managed launch parity remain active work.
+- Browser/runtime split and direct app entry are current convergence work across `constitute-account`, `constitute-ui`, `constitute-gateway-ui`, and app surfaces.
 
 ## Phase Plan
 
@@ -28,7 +29,7 @@ Objectives:
 
 Exit criteria:
 - contract docs reviewed and stable across repos
-- compatibility defaults documented
+- default behavior documented without stale aliases
 - no unresolved schema ambiguity for launch/signaling records
 
 ### Phase B: Gateway Managed Launch and Signaling
@@ -58,18 +59,19 @@ Exit criteria:
 
 ### Phase D: Shell and App Surface Convergence
 Objectives:
-- make `constitute` a clean management shell plus launcher
+- retire launcher-first shell framing in favor of direct app entry plus `constitute-account`
 - make `constitute-nvr-ui` a clean Pages-hosted app surface
 - remove long-lived secret expectations from managed app launch
+- ensure direct app entry does not require a manual account visit before app use
 
 Exit criteria:
 - first-party app launch opens separate app surface cleanly
-- shell surfaces service-backed devices distinctly from user devices
+- account and gateway surfaces keep service-backed devices distinct from user devices
 - launch context/bootstrap works without query-string secrets
 
 ## Known Risks and Controls
 - Risk: contract drift during active iteration.
-  - Control: protocol-first changes and compatibility test vectors.
+  - Control: protocol-first changes and cross-repo test vectors.
 - Risk: WebRTC complexity slows delivery.
   - Control: keep gateway as signaling boundary and preserve recorded-media fallback.
 - Risk: shell/app bootstrap leaks secrets.
@@ -85,3 +87,31 @@ Exit criteria:
 - No repository-managed OS image/media generation path.
 - Dev: clone repository, build locally, install service locally.
 - Release: install/update service from tagged release artifacts.
+
+## Current / Planned Later Phases
+
+The product-surface split is current local convergence work. Host-capability services are planned later.
+
+### Phase E: Product-Surface Split
+Objectives:
+- keep `constitute-account` as the browser identity/session/grant authority
+- make direct app entry canonical instead of shell-launcher-first
+- keep gateway-specific management in `constitute-gateway-ui`
+
+Exit criteria:
+- account/profile/device/grant management has a clear primary app boundary
+- gateway-specific host/service management has a separate UI home
+- launcher behavior is convenience/navigation rather than the required primary flow
+
+### Phase F: Host-Capability Services
+Objectives:
+- introduce cryptographic media projection and warm NVR stream planning before burying stream lifecycle in gateway or recording
+- introduce `constitute-security` as a host-local capability service surfaced in UI as `Security`
+- introduce `constitute-storage` as a host-local capability service for encrypted content-addressed object/archive semantics
+- keep gateway as orchestrator/projector of those capabilities rather than making it their permanent implementation home
+
+Exit criteria:
+- gateway remains admission/signaling/orchestration boundary rather than routine media data path
+- workloads can request capability leases instead of embedding security/storage logic directly
+- hostile camera-network posture and higher-level anomaly reporting have an explicit home
+- durable object/blob/archive semantics have an explicit shared home without forcing all service config/runtime state into storage

--- a/scripts/linux/install-service.sh
+++ b/scripts/linux/install-service.sh
@@ -189,8 +189,7 @@ else:
 
 default_relays = [item.strip() for item in os.environ.get("DEFAULT_NOSTR_RELAYS", "").split(",") if item.strip()]
 existing_relays = [str(item).strip() for item in cfg.get("nostr_relays", []) if str(item).strip()]
-legacy_defaults = {"wss://relay.snort.social", "wss://relay.damus.io"}
-if not existing_relays or set(existing_relays).issubset(legacy_defaults):
+if not existing_relays:
     cfg["nostr_relays"] = default_relays
 
 relay_port = str(os.environ.get("RELAY_PORT", "7447")).strip() or "7447"

--- a/scripts/windows/install-service.ps1
+++ b/scripts/windows/install-service.ps1
@@ -11,7 +11,6 @@ param(
 $ErrorActionPreference = 'Stop'
 $repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $configExample = Join-Path $repo 'config.example.json'
-$legacyConfig = Join-Path $repo 'config.json'
 
 function Download-WithRetry([string]$Uri, [string]$OutFile, [int]$Retries = 4, [int]$DelaySec = 2) {
     for ($i = 0; $i -le $Retries; $i++) {
@@ -109,13 +108,11 @@ function Normalize-Config {
     }
 
     $defaultRelays = @('wss://nos.lol', 'wss://relay.primal.net', 'wss://nostr.mom')
-    $legacyRelays = @('wss://relay.snort.social', 'wss://relay.damus.io')
     $existingRelays = @()
     if ($null -ne $cfg.nostr_relays) {
         $existingRelays = @($cfg.nostr_relays | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     }
-    $hasCustomRelay = ($existingRelays | Where-Object { $_ -notin $legacyRelays }).Count -gt 0
-    if ($existingRelays.Count -eq 0 -or -not $hasCustomRelay) {
+    if ($existingRelays.Count -eq 0) {
         $cfg | Add-Member -NotePropertyName nostr_relays -NotePropertyValue $defaultRelays -Force
     }
 
@@ -263,18 +260,11 @@ New-Item -ItemType Directory -Force -Path $dataDir | Out-Null
 New-Item -ItemType Directory -Force -Path $logsDir | Out-Null
 
 if (-not (Test-Path $ConfigPath)) {
-    if (Test-Path $legacyConfig) {
-        Copy-Item $legacyConfig $ConfigPath -Force
-    } elseif (Test-Path $configExample) {
+    if (Test-Path $configExample) {
         Copy-Item $configExample $ConfigPath -Force
     } else {
-        throw "config template missing: expected $legacyConfig or $configExample"
+        throw "config template missing: expected $configExample"
     }
-}
-
-$legacyDataDir = Join-Path $repo 'data'
-if (Test-Path $legacyDataDir) {
-    Copy-Item -Path (Join-Path $legacyDataDir '*') -Destination $dataDir -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 $generatedPairCode = Normalize-Config -Path $ConfigPath -StateRootPath $StateRoot -DefaultDataDir $dataDir -PairIdentityLabel $PairIdentity -ShouldGeneratePairCode $PairGenerate.IsPresent

--- a/src/bin/mission_probe.rs
+++ b/src/bin/mission_probe.rs
@@ -14,6 +14,7 @@ struct Cli {
     command: Command,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum Command {
     RecoverSk {
@@ -76,7 +77,10 @@ async fn recover_sk(partial: &str, expected_pk: &str) -> Result<()> {
     let partial = hexish(partial);
     let expected_pk = expected_pk.trim().to_ascii_lowercase();
     if partial.len() != 63 {
-        return Err(anyhow!("expected a 63-hex partial secret, got {}", partial.len()));
+        return Err(anyhow!(
+            "expected a 63-hex partial secret, got {}",
+            partial.len()
+        ));
     }
     for nibble in "0123456789abcdef".chars() {
         let candidate = format!("{nibble}{partial}");
@@ -104,7 +108,7 @@ async fn request_launch(args: &RequestLaunchArgs) -> Result<()> {
             "limit": 200
         }
     ]))?;
-    socket.send(Message::Text(req_frame.into())).await?;
+    socket.send(Message::Text(req_frame)).await?;
 
     let request_id = format!("gw-launch-{}", random_suffix());
     let payload = json!({
@@ -137,7 +141,7 @@ async fn request_launch(args: &RequestLaunchArgs) -> Result<()> {
     );
     let event = nostr::sign_event(&unsigned, &args.sk)?;
     let event_frame = serde_json::to_string(&json!(["EVENT", event]))?;
-    socket.send(Message::Text(event_frame.into())).await?;
+    socket.send(Message::Text(event_frame)).await?;
 
     let timeout = tokio::time::sleep(std::time::Duration::from_secs(25));
     tokio::pin!(timeout);
@@ -209,7 +213,10 @@ struct RequestLaunchArgs {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Command::RecoverSk { partial, expected_pk } => recover_sk(&partial, &expected_pk).await,
+        Command::RecoverSk {
+            partial,
+            expected_pk,
+        } => recover_sk(&partial, &expected_pk).await,
         Command::RequestLaunch {
             relay,
             sk,

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -121,6 +121,7 @@ pub struct SwarmDeviceRecord {
 }
 
 impl SwarmDeviceRecord {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         device_pk: &str,
         identity_id: &str,
@@ -244,6 +245,7 @@ impl HostedServiceRecord {
 }
 
 impl DiscoveryClient {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool: relay::RelayPool,
         device_record: SwarmDeviceRecord,

--- a/src/grants.rs
+++ b/src/grants.rs
@@ -221,7 +221,9 @@ fn lease_key(service_pk: &str, source_id: &str) -> String {
 
 fn cleanup_control_leases(state: &mut GrantState) {
     let now_ms = util::now_unix_seconds() * 1000;
-    state.control_leases.retain(|_, lease| lease.expires_at > now_ms);
+    state
+        .control_leases
+        .retain(|_, lease| lease.expires_at > now_ms);
 }
 
 fn persist_grants(data_dir: &str, state: &GrantState) -> Result<()> {
@@ -244,7 +246,8 @@ pub(super) fn load_grant_state(data_dir: &str) -> GrantState {
         Ok(raw) => raw,
         Err(_) => return GrantState::default(),
     };
-    let parsed: PersistedGrantStore = serde_json::from_str(&raw).unwrap_or(PersistedGrantStore { grants: Vec::new() });
+    let parsed: PersistedGrantStore =
+        serde_json::from_str(&raw).unwrap_or(PersistedGrantStore { grants: Vec::new() });
     GrantState {
         grants: parsed.grants,
         control_leases: HashMap::new(),
@@ -433,7 +436,10 @@ pub(super) async fn resolve_scope_for_request(
     capability: &str,
     cameras: &[CameraResource],
 ) -> Result<GrantScope> {
-    if !matches!((service.trim(), capability.trim()), ("nvr", "nvr.view") | ("nvr", "nvr.manage") | ("nvr", "gateway.launch_managed_app")) {
+    if !matches!(
+        (service.trim(), capability.trim()),
+        ("nvr", "nvr.view") | ("nvr", "nvr.manage") | ("nvr", "gateway.launch_managed_app")
+    ) {
         return Err(anyhow!("unsupported capability"));
     }
     if !requester_matches_identity(ctx, requester_pk, identity_id).await {
@@ -580,55 +586,117 @@ pub(super) async fn handle_gateway_grant_request(
         req.device_pk = requester_pk.clone();
     }
 
-    let publish_status = |status: &str,
-                          grant: Option<Value>,
-                          grants: Option<Value>,
-                          shared_resources: Option<Value>,
-                          available_cameras: Option<Value>,
-                          reason: Option<String>,
-                          detail: Option<String>| GatewayGrantStatusPayload {
-        kind: "gateway_grant_status".to_string(),
-        request_id: req.request_id.clone(),
-        status: status.to_string(),
-        to_device_pk: req.to_device_pk.clone(),
-        gateway_pk: ctx.self_pk.clone(),
-        identity_id: req.identity_id.clone(),
-        device_pk: req.device_pk.clone(),
-        service_pk: req.service_pk.clone(),
-        service: req.service.clone(),
-        action: req.action.clone(),
-        grant,
-        grants,
-        shared_resources,
-        available_cameras,
-        control_lease: None,
-        reason,
-        detail,
-        ts: util::now_unix_seconds() * 1000,
-    };
+    let publish_status =
+        |status: &str,
+         grant: Option<Value>,
+         grants: Option<Value>,
+         shared_resources: Option<Value>,
+         available_cameras: Option<Value>,
+         reason: Option<String>,
+         detail: Option<String>| GatewayGrantStatusPayload {
+            kind: "gateway_grant_status".to_string(),
+            request_id: req.request_id.clone(),
+            status: status.to_string(),
+            to_device_pk: req.to_device_pk.clone(),
+            gateway_pk: ctx.self_pk.clone(),
+            identity_id: req.identity_id.clone(),
+            device_pk: req.device_pk.clone(),
+            service_pk: req.service_pk.clone(),
+            service: req.service.clone(),
+            action: req.action.clone(),
+            grant,
+            grants,
+            shared_resources,
+            available_cameras,
+            control_lease: None,
+            reason,
+            detail,
+            ts: util::now_unix_seconds() * 1000,
+        };
 
     if requester_pk != req.device_pk {
-        let status = publish_status("rejected", None, None, None, None, Some("requester_device_mismatch".to_string()), Some("requesting event pubkey does not match devicePk".to_string()));
-        let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+        let status = publish_status(
+            "rejected",
+            None,
+            None,
+            None,
+            None,
+            Some("requester_device_mismatch".to_string()),
+            Some("requesting event pubkey does not match devicePk".to_string()),
+        );
+        let _ = publish_gateway_grant_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
         return;
     }
 
     if !requester_matches_identity(ctx, &requester_pk, &req.identity_id).await {
-        let status = publish_status("rejected", None, None, None, None, Some("unauthorized_requester".to_string()), Some("requester is not authorized for this identity".to_string()));
-        let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+        let status = publish_status(
+            "rejected",
+            None,
+            None,
+            None,
+            None,
+            Some("unauthorized_requester".to_string()),
+            Some("requester is not authorized for this identity".to_string()),
+        );
+        let _ = publish_gateway_grant_status(
+            &ctx.relay_pool,
+            &ctx.local_relay,
+            &ctx.self_pk,
+            &ctx.self_sk,
+            &status,
+        )
+        .await;
         return;
     }
 
-    let hosted = match managed::load_target_hosted_service(ctx, &req.service_pk, &req.service).await {
+    let hosted = match managed::load_target_hosted_service(ctx, &req.service_pk, &req.service).await
+    {
         Ok(service) => service,
         Err(err) => {
             if req.action == "list_shared" {
-                let status = publish_status("complete", None, None, Some(json!([])), Some(json!([])), None, None);
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "complete",
+                    None,
+                    None,
+                    Some(json!([])),
+                    Some(json!([])),
+                    None,
+                    None,
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             }
-            let status = publish_status("failed", None, None, None, None, Some("service_unavailable".to_string()), Some(err.to_string()));
-            let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+            let status = publish_status(
+                "failed",
+                None,
+                None,
+                None,
+                None,
+                Some("service_unavailable".to_string()),
+                Some(err.to_string()),
+            );
+            let _ = publish_gateway_grant_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
             return;
         }
     };
@@ -636,17 +704,57 @@ pub(super) async fn handle_gateway_grant_request(
 
     match req.action.as_str() {
         "list_shared" => {
-            let shared_resources = match scope_for_identity(ctx, &req.identity_id, &hosted.record.device_pk, &hosted.record.service, &cameras).await {
-                Ok(scope) if !scope.owner => json!([build_shared_resource_projection(&hosted, &scope)]),
+            let shared_resources = match scope_for_identity(
+                ctx,
+                &req.identity_id,
+                &hosted.record.device_pk,
+                &hosted.record.service,
+                &cameras,
+            )
+            .await
+            {
+                Ok(scope) if !scope.owner => {
+                    json!([build_shared_resource_projection(&hosted, &scope)])
+                }
                 _ => json!([]),
             };
-            let status = publish_status("complete", None, None, Some(shared_resources), Some(camera_list_items(&cameras)), None, None);
-            let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+            let status = publish_status(
+                "complete",
+                None,
+                None,
+                Some(shared_resources),
+                Some(camera_list_items(&cameras)),
+                None,
+                None,
+            );
+            let _ = publish_gateway_grant_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
         }
         "list_grants" => {
             if req.identity_id.trim() != ctx.gateway_identity_id.trim() {
-                let status = publish_status("rejected", None, None, None, None, Some("owner_required".to_string()), Some("only the gateway owner can list grants".to_string()));
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "rejected",
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("owner_required".to_string()),
+                    Some("only the gateway owner can list grants".to_string()),
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             }
             let grants_value = {
@@ -659,42 +767,138 @@ pub(super) async fn handle_gateway_grant_request(
                         .filter(|grant| active_grant(grant))
                         .filter(|grant| grant.gateway_pk.trim() == ctx.self_pk.trim())
                         .filter(|grant| grant.service_pk.trim() == hosted.record.device_pk.trim())
-                        .filter(|grant| grant.service.trim().eq_ignore_ascii_case(&hosted.record.service))
+                        .filter(|grant| {
+                            grant
+                                .service
+                                .trim()
+                                .eq_ignore_ascii_case(&hosted.record.service)
+                        })
                         .map(grant_view)
                         .collect(),
                 )
             };
-            let status = publish_status("complete", None, Some(grants_value), None, Some(camera_list_items(&cameras)), None, None);
-            let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+            let status = publish_status(
+                "complete",
+                None,
+                Some(grants_value),
+                None,
+                Some(camera_list_items(&cameras)),
+                None,
+                None,
+            );
+            let _ = publish_gateway_grant_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
         }
         "upsert" => {
             if req.identity_id.trim() != ctx.gateway_identity_id.trim() {
-                let status = publish_status("rejected", None, None, None, None, Some("owner_required".to_string()), Some("only the gateway owner can modify grants".to_string()));
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "rejected",
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("owner_required".to_string()),
+                    Some("only the gateway owner can modify grants".to_string()),
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             }
             if req.grantee_identity_id.is_empty() {
-                let status = publish_status("rejected", None, None, None, None, Some("missing_grantee".to_string()), Some("granteeIdentityId is required".to_string()));
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "rejected",
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("missing_grantee".to_string()),
+                    Some("granteeIdentityId is required".to_string()),
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             }
             if req.grantee_identity_id.trim() == ctx.gateway_identity_id.trim() {
-                let status = publish_status("rejected", None, None, None, None, Some("invalid_grantee".to_string()), Some("owner does not need an explicit grant".to_string()));
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "rejected",
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("invalid_grantee".to_string()),
+                    Some("owner does not need an explicit grant".to_string()),
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             }
-            let available_view = dedup_source_ids(cameras.iter().map(|camera| camera.source_id.clone()));
-            let available_control = dedup_source_ids(cameras.iter().filter(|camera| camera.ptz_capable).map(|camera| camera.source_id.clone()));
-            let mut view_sources = dedup_source_ids(req.view_sources.iter().filter(|source| available_view.contains(source)).cloned());
-            let control_sources = dedup_source_ids(req.control_sources.iter().filter(|source| available_control.contains(source)).cloned());
+            let available_view =
+                dedup_source_ids(cameras.iter().map(|camera| camera.source_id.clone()));
+            let available_control = dedup_source_ids(
+                cameras
+                    .iter()
+                    .filter(|camera| camera.ptz_capable)
+                    .map(|camera| camera.source_id.clone()),
+            );
+            let mut view_sources = dedup_source_ids(
+                req.view_sources
+                    .iter()
+                    .filter(|source| available_view.contains(source))
+                    .cloned(),
+            );
+            let control_sources = dedup_source_ids(
+                req.control_sources
+                    .iter()
+                    .filter(|source| available_control.contains(source))
+                    .cloned(),
+            );
             for source in &control_sources {
                 if !view_sources.contains(source) {
                     view_sources.push(source.clone());
                 }
             }
             if view_sources.is_empty() {
-                let status = publish_status("rejected", None, None, None, Some(camera_list_items(&cameras)), Some("missing_view_sources".to_string()), Some("select at least one camera to grant live view".to_string()));
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "rejected",
+                    None,
+                    None,
+                    None,
+                    Some(camera_list_items(&cameras)),
+                    Some("missing_view_sources".to_string()),
+                    Some("select at least one camera to grant live view".to_string()),
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             }
             let now_ms = util::now_unix_seconds() * 1000;
@@ -705,7 +909,10 @@ pub(super) async fn handle_gateway_grant_request(
                     active_grant(grant)
                         && grant.gateway_pk.trim() == ctx.self_pk.trim()
                         && grant.service_pk.trim() == hosted.record.device_pk.trim()
-                        && grant.service.trim().eq_ignore_ascii_case(&hosted.record.service)
+                        && grant
+                            .service
+                            .trim()
+                            .eq_ignore_ascii_case(&hosted.record.service)
                         && grant.grantee_identity_id.trim() == req.grantee_identity_id.trim()
                 });
                 let grant = if let Some(index) = existing_idx {
@@ -717,7 +924,11 @@ pub(super) async fn handle_gateway_grant_request(
                     grant.clone()
                 } else {
                     let grant = GatewayGrantRecord {
-                        grant_id: if req.grant_id.is_empty() { format!("grant-{}", random_hex(8)) } else { req.grant_id.clone() },
+                        grant_id: if req.grant_id.is_empty() {
+                            format!("grant-{}", random_hex(8))
+                        } else {
+                            req.grant_id.clone()
+                        },
                         owner_identity_id: ctx.gateway_identity_id.clone(),
                         grantee_identity_id: req.grantee_identity_id.clone(),
                         gateway_pk: ctx.self_pk.clone(),
@@ -737,13 +948,43 @@ pub(super) async fn handle_gateway_grant_request(
                 }
                 grant
             };
-            let status = publish_status("complete", Some(grant_view(&grant)), None, None, Some(camera_list_items(&cameras)), None, None);
-            let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+            let status = publish_status(
+                "complete",
+                Some(grant_view(&grant)),
+                None,
+                None,
+                Some(camera_list_items(&cameras)),
+                None,
+                None,
+            );
+            let _ = publish_gateway_grant_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
         }
         "revoke" => {
             if req.identity_id.trim() != ctx.gateway_identity_id.trim() {
-                let status = publish_status("rejected", None, None, None, None, Some("owner_required".to_string()), Some("only the gateway owner can revoke grants".to_string()));
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "rejected",
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("owner_required".to_string()),
+                    Some("only the gateway owner can revoke grants".to_string()),
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             }
             let revoked = {
@@ -754,9 +995,14 @@ pub(super) async fn handle_gateway_grant_request(
                 for grant in &mut grant_state.grants {
                     let matches_service = grant.gateway_pk.trim() == ctx.self_pk.trim()
                         && grant.service_pk.trim() == hosted.record.device_pk.trim()
-                        && grant.service.trim().eq_ignore_ascii_case(&hosted.record.service);
-                    let matches_grant = (!req.grant_id.is_empty() && grant.grant_id.trim() == req.grant_id.trim())
-                        || (!req.grantee_identity_id.is_empty() && grant.grantee_identity_id.trim() == req.grantee_identity_id.trim());
+                        && grant
+                            .service
+                            .trim()
+                            .eq_ignore_ascii_case(&hosted.record.service);
+                    let matches_grant = (!req.grant_id.is_empty()
+                        && grant.grant_id.trim() == req.grant_id.trim())
+                        || (!req.grantee_identity_id.is_empty()
+                            && grant.grantee_identity_id.trim() == req.grantee_identity_id.trim());
                     if active_grant(grant) && matches_service && matches_grant {
                         grant.revoked_at = now_ms;
                         grant.updated_at = now_ms;
@@ -772,16 +1018,61 @@ pub(super) async fn handle_gateway_grant_request(
                 out
             };
             let Some(revoked) = revoked else {
-                let status = publish_status("rejected", None, None, None, Some(camera_list_items(&cameras)), Some("grant_not_found".to_string()), Some("matching active grant was not found".to_string()));
-                let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+                let status = publish_status(
+                    "rejected",
+                    None,
+                    None,
+                    None,
+                    Some(camera_list_items(&cameras)),
+                    Some("grant_not_found".to_string()),
+                    Some("matching active grant was not found".to_string()),
+                );
+                let _ = publish_gateway_grant_status(
+                    &ctx.relay_pool,
+                    &ctx.local_relay,
+                    &ctx.self_pk,
+                    &ctx.self_sk,
+                    &status,
+                )
+                .await;
                 return;
             };
-            let status = publish_status("complete", Some(grant_view(&revoked)), None, None, Some(camera_list_items(&cameras)), None, None);
-            let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+            let status = publish_status(
+                "complete",
+                Some(grant_view(&revoked)),
+                None,
+                None,
+                Some(camera_list_items(&cameras)),
+                None,
+                None,
+            );
+            let _ = publish_gateway_grant_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
         }
         _ => {
-            let status = publish_status("rejected", None, None, None, None, Some("unsupported_action".to_string()), Some("unsupported gateway grant action".to_string()));
-            let _ = publish_gateway_grant_status(&ctx.relay_pool, &ctx.local_relay, &ctx.self_pk, &ctx.self_sk, &status).await;
+            let status = publish_status(
+                "rejected",
+                None,
+                None,
+                None,
+                None,
+                Some("unsupported_action".to_string()),
+                Some("unsupported gateway grant action".to_string()),
+            );
+            let _ = publish_gateway_grant_status(
+                &ctx.relay_pool,
+                &ctx.local_relay,
+                &ctx.self_pk,
+                &ctx.self_sk,
+                &status,
+            )
+            .await;
         }
     }
 }

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -330,7 +330,7 @@ fn encrypt_payload(payload: &StorePayload, key_source: &KeySource) -> Result<Enc
         version: 1,
         kdf,
         salt_b64: STANDARD_NO_PAD.encode(&salt),
-        nonce_b64: STANDARD_NO_PAD.encode(&nonce),
+        nonce_b64: STANDARD_NO_PAD.encode(nonce),
         ciphertext_b64: STANDARD_NO_PAD.encode(&ciphertext),
         mem_kib,
         iterations,

--- a/src/local_relay.rs
+++ b/src/local_relay.rs
@@ -180,6 +180,7 @@ fn load_tls_acceptor(cert_path: &str, key_path: &str) -> Result<TlsAcceptor> {
     Ok(TlsAcceptor::from(Arc::new(cfg)))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_ws_listener(
     listener: TcpListener,
     bind: String,
@@ -229,6 +230,7 @@ fn spawn_ws_listener(
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 fn spawn_wss_listener(
     listener: TcpListener,
     bind: String,
@@ -552,6 +554,7 @@ async fn publish_event(
 }
 
 // Each client connection maintains subscription filters and enforces per-connection limits.
+#[allow(clippy::too_many_arguments)]
 async fn handle_client<S>(
     stream: S,
     addr: SocketAddr,
@@ -773,8 +776,8 @@ fn event_has_tag_any(ev: &Value, key: &str, values: &[String]) -> bool {
 }
 
 fn is_allowed_event(ev: &Value) -> bool {
-    event_has_tag_any(ev, "t", &vec!["constitute".to_string()])
-        || event_has_tag_any(ev, "t", &vec!["swarm_discovery".to_string()])
+    event_has_tag_any(ev, "t", &["constitute".to_string()])
+        || event_has_tag_any(ev, "t", &["swarm_discovery".to_string()])
 }
 
 #[cfg(test)]
@@ -940,27 +943,24 @@ mod tests {
             tokio::select! {
                 _ = &mut deadline => break,
                 msg = w2_rx.next() => {
-                    match msg {
-                        Some(Ok(Message::Text(txt))) => {
-                            let v: Value = match serde_json::from_str(&txt) {
-                                Ok(v) => v,
-                                Err(_) => continue,
-                            };
-                            let arr = match v.as_array() {
-                                Some(a) => a,
-                                None => continue,
-                            };
-                            if arr.get(0).and_then(|v| v.as_str()) != Some("EVENT") {
-                                continue;
-                            }
-                            let ev_val = if arr.len() >= 3 { &arr[2] } else { &arr[1] };
-                            let id = ev_val.get("id").and_then(|v| v.as_str()).unwrap_or("");
-                            if id == ev_id {
-                                received = true;
-                                break;
-                            }
+                    if let Some(Ok(Message::Text(txt))) = msg {
+                        let v: Value = match serde_json::from_str(&txt) {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+                        let arr = match v.as_array() {
+                            Some(a) => a,
+                            None => continue,
+                        };
+                        if arr.first().and_then(|v| v.as_str()) != Some("EVENT") {
+                            continue;
                         }
-                        _ => {}
+                        let ev_val = if arr.len() >= 3 { &arr[2] } else { &arr[1] };
+                        let id = ev_val.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                        if id == ev_id {
+                            received = true;
+                            break;
+                        }
                     }
                 }
             }
@@ -1040,7 +1040,7 @@ mod tests {
                         Err(_) => continue,
                     };
                     let arr = match v.as_array() { Some(a) => a, None => continue };
-                    if arr.get(0).and_then(|v| v.as_str()) == Some("EVENT") {
+                    if arr.first().and_then(|v| v.as_str()) == Some("EVENT") {
                         saw_event = true;
                         break;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,17 +11,18 @@ mod transport;
 mod util;
 
 use crate::swarm_store::{RecordType, SwarmStoreMap};
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use clap::{ArgAction, Parser};
 use futures_util::{SinkExt, StreamExt};
 use rand::RngCore;
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+#[cfg(all(feature = "platform-linux", not(feature = "platform-windows")))]
 use std::process::Command;
 #[cfg(all(feature = "platform-linux", not(feature = "platform-windows")))]
 use std::process::Stdio;
@@ -65,8 +66,6 @@ struct Config {
     node_id: String,
     #[serde(default = "default_node_role")]
     node_role: String,
-    #[serde(default)]
-    node_type: Option<String>,
     #[serde(default = "default_bind")]
     bind: String,
     #[serde(default = "default_data_dir")]
@@ -220,8 +219,8 @@ struct GatewayServiceInstallRequest {
     swarm_peers: Vec<String>,
     #[serde(rename = "publicWsUrl", default)]
     public_ws_url: String,
-    #[serde(rename = "allowUnsignedHelloMvp", default)]
-    allow_unsigned_hello_mvp: Option<bool>,
+    #[serde(rename = "allowUnsignedDebugHello", default)]
+    allow_unsigned_debug_hello: Option<bool>,
     #[serde(rename = "reolinkAutoprovision", default)]
     reolink_autoprovision: Option<bool>,
     #[serde(rename = "reolinkUsername", default)]
@@ -439,7 +438,6 @@ struct GatewaySignalPayload {
     ts: u64,
 }
 
-
 #[derive(Debug, Clone, Deserialize)]
 struct PairApprovePayload {
     #[serde(default)]
@@ -500,11 +498,6 @@ fn normalize_node_role(value: &str) -> Option<String> {
 fn resolve_node_role(cfg: &Config) -> String {
     if let Some(role) = normalize_node_role(&cfg.node_role) {
         return role;
-    }
-    if let Some(legacy) = cfg.node_type.as_deref() {
-        if let Some(role) = normalize_node_role(legacy) {
-            return role;
-        }
     }
     default_node_role()
 }
@@ -1023,7 +1016,7 @@ async fn main() -> Result<()> {
         peers: cfg.udp_peers.clone(),
         handshake_interval: Duration::from_secs(cfg.udp_handshake_interval_secs),
         peer_timeout: Duration::from_secs(cfg.udp_peer_timeout_secs),
-        max_packet_bytes: cfg.udp_max_packet_bytes.max(512).min(65507) as usize,
+        max_packet_bytes: cfg.udp_max_packet_bytes.clamp(512, 65507) as usize,
         rate_limit_per_sec: cfg.udp_rate_limit_per_sec,
         request_fanout: cfg.udp_request_fanout as usize,
         request_max_hops: cfg.udp_request_max_hops,
@@ -1048,7 +1041,7 @@ async fn main() -> Result<()> {
             peers: quic_peers,
             handshake_interval: Duration::from_secs(cfg.udp_handshake_interval_secs.max(1)),
             peer_timeout: Duration::from_secs(cfg.udp_peer_timeout_secs.max(10)),
-            max_packet_bytes: cfg.udp_max_packet_bytes.max(512).min(65507) as usize,
+            max_packet_bytes: cfg.udp_max_packet_bytes.clamp(512, 65507) as usize,
             rate_limit_per_sec: cfg.udp_rate_limit_per_sec,
             request_fanout: cfg.udp_request_fanout as usize,
             request_max_hops: cfg.udp_request_max_hops,
@@ -1168,9 +1161,11 @@ async fn main() -> Result<()> {
         let mut ticker = tokio::time::interval(Duration::from_secs(10));
         loop {
             ticker.tick().await;
-            let snapshot =
-                managed::load_hosted_services_snapshot(&hosted_services_client, &hosted_services_gateway_pk)
-                    .await;
+            let snapshot = managed::load_hosted_services_snapshot(
+                &hosted_services_client,
+                &hosted_services_gateway_pk,
+            )
+            .await;
             if hosted_services_tx.send(snapshot.clone()).is_err() {
                 break;
             }
@@ -1439,7 +1434,7 @@ async fn main() -> Result<()> {
 
 fn has_tag(tags: &[Vec<String>], key: &str, value: &str) -> bool {
     tags.iter().any(|t| {
-        t.get(0).map(|v| v.as_str()) == Some(key) && t.get(1).map(|v| v.as_str()) == Some(value)
+        t.first().map(|v| v.as_str()) == Some(key) && t.get(1).map(|v| v.as_str()) == Some(value)
     })
 }
 
@@ -1480,7 +1475,7 @@ fn request_timeout(payload: &Value) -> Duration {
         .get("timeoutMs")
         .and_then(|v| v.as_u64())
         .unwrap_or(5000);
-    let capped = ms.max(500).min(30000);
+    let capped = ms.clamp(500, 30000);
     Duration::from_millis(capped)
 }
 
@@ -1622,8 +1617,8 @@ fn execute_nvr_install_request(
         req.pair_code_hash.clone(),
     ];
 
-    if req.allow_unsigned_hello_mvp.unwrap_or(true) {
-        args.push("--allow-unsigned-hello-mvp".to_string());
+    if req.allow_unsigned_debug_hello.unwrap_or(true) {
+        args.push("--allow-unsigned-debug-hello".to_string());
     } else {
         args.push("--require-signed-hello".to_string());
     }
@@ -1839,6 +1834,7 @@ async fn publish_record_app_event_with_request(
 }
 
 // Pending request state exists to bridge async record arrival with request/response UX.
+#[allow(clippy::too_many_arguments)]
 async fn match_pending_requests(
     pending: &Arc<Mutex<HashMap<String, PendingRequest>>>,
     relay_pool: &relay::RelayPool,
@@ -2125,6 +2121,7 @@ fn build_gateway_service_install_status_payload(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_gateway_zone_sync_status_payload(
     req: &GatewayZoneSyncRequest,
     gateway_pk: &str,
@@ -2153,6 +2150,7 @@ fn build_gateway_zone_sync_status_payload(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_gateway_managed_launch_status_payload(
     req: &GatewayManagedLaunchRequest,
     gateway_pk: &str,
@@ -2243,7 +2241,8 @@ fn service_sources_from_config(cameras: &[Value]) -> Vec<String> {
     cameras
         .iter()
         .filter_map(|entry| {
-            entry.get("source_id")
+            entry
+                .get("source_id")
                 .and_then(|v| v.as_str())
                 .or_else(|| entry.get("sourceId").and_then(|v| v.as_str()))
                 .map(|v| v.trim().to_string())
@@ -2251,7 +2250,6 @@ fn service_sources_from_config(cameras: &[Value]) -> Vec<String> {
         .filter(|entry| !entry.is_empty())
         .collect()
 }
-
 
 fn build_device_record_event(
     pubkey: &str,
@@ -2273,6 +2271,7 @@ fn build_device_record_event(
     nostr::sign_event(&unsigned, sk_hex)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn publish_current_device_record(
     pubkey: &str,
     sk_hex: &str,
@@ -2407,10 +2406,10 @@ fn is_self_test_ack(frame: &str, event_id: &str) -> bool {
         }
         Some("EVENT") => {
             let ev = arr.get(1).and_then(|v| v.as_object());
-            match ev.and_then(|o| o.get("id")).and_then(|v| v.as_str()) {
-                Some(id) if id == event_id => true,
-                _ => false,
-            }
+            matches!(
+                ev.and_then(|o| o.get("id")).and_then(|v| v.as_str()),
+                Some(id) if id == event_id
+            )
         }
         _ => false,
     }
@@ -2422,7 +2421,7 @@ fn extract_event(frame: &str) -> Option<Value> {
     if arr.is_empty() {
         return None;
     }
-    if arr.get(0)?.as_str()? != "EVENT" {
+    if arr.first()?.as_str()? != "EVENT" {
         return None;
     }
     let ev_val = if arr.len() >= 3 { &arr[2] } else { &arr[1] };
@@ -2491,7 +2490,7 @@ fn is_mesh_passthrough_kind(kind: &str) -> bool {
 fn event_zone_tags(ev: &nostr::NostrEvent, zone_keys: &HashSet<String>) -> Vec<String> {
     let mut out = Vec::new();
     for tag in &ev.tags {
-        if tag.get(0).map(|v| v.as_str()) != Some("z") {
+        if tag.first().map(|v| v.as_str()) != Some("z") {
             continue;
         }
         let z = tag.get(1).map(|v| v.trim()).unwrap_or("");
@@ -2680,6 +2679,7 @@ async fn mesh_request_dht_record(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn mesh_forward_record_request(
     udp: &Arc<transport::UdpHandle>,
     quic: Option<&Arc<transport::QuicHandle>>,
@@ -2995,10 +2995,8 @@ async fn process_inbound_event(
                 }
             }
         }
-        if kind == "pair_approve" {
-            if handle_pair_approve_event(&ctx, &nostr_ev, &payload).await {
-                return;
-            }
+        if kind == "pair_approve" && handle_pair_approve_event(&ctx, &nostr_ev, &payload).await {
+            return;
         }
 
         if kind == "gateway_service_install_request" {
@@ -3026,7 +3024,7 @@ async fn process_inbound_event(
             return;
         }
 
-        if kind == "swarm_record_request" || kind == "swarm_discovery_request" {
+        if kind == "swarm_record_request" {
             let zone = payload_zone(&payload);
             let identity_id = payload
                 .get("identityId")
@@ -3706,7 +3704,7 @@ fn round_pct(value: f32) -> f32 {
     if !value.is_finite() {
         return 0.0;
     }
-    let clamped = value.max(0.0).min(100.0);
+    let clamped = value.clamp(0.0, 100.0);
     (clamped * 10.0).round() / 10.0
 }
 fn random_hex(bytes_len: usize) -> String {
@@ -3732,7 +3730,7 @@ fn save_config(path: &PathBuf, cfg: &Config) -> Option<()> {
 fn collect_seed_zones(data_dir: &str, args_zones: &[String]) -> Vec<ZoneConfig> {
     let mut zones: Vec<ZoneConfig> = Vec::new();
 
-    if let Some(k) = read_zone_seed_snapctl() {
+    if let Some(k) = read_zone_seed_file(data_dir) {
         if util::is_valid_zone_key(&k) {
             zones.push(ZoneConfig {
                 key: k,
@@ -3742,22 +3740,11 @@ fn collect_seed_zones(data_dir: &str, args_zones: &[String]) -> Vec<ZoneConfig> 
     }
 
     if zones.is_empty() {
-        if let Some(k) = read_zone_seed_file(data_dir) {
-            if util::is_valid_zone_key(&k) {
-                zones.push(ZoneConfig {
-                    key: k,
-                    name: "Joined".to_string(),
-                });
-            }
-        }
-    }
-
-    if zones.is_empty() {
         if let Ok(k) = std::env::var("CONSTITUTE_GATEWAY_ZONE") {
             let key = k.trim().to_string();
             if util::is_valid_zone_key(&key) {
                 zones.push(ZoneConfig {
-                    key: key,
+                    key,
                     name: "Joined".to_string(),
                 });
             }
@@ -3769,7 +3756,7 @@ fn collect_seed_zones(data_dir: &str, args_zones: &[String]) -> Vec<ZoneConfig> 
             let key = k.trim().to_string();
             if util::is_valid_zone_key(&key) {
                 zones.push(ZoneConfig {
-                    key: key,
+                    key,
                     name: "Joined".to_string(),
                 });
             }
@@ -3791,27 +3778,6 @@ fn read_zone_seed_file(data_dir: &str) -> Option<String> {
     }
 }
 
-fn read_zone_seed_snapctl() -> Option<String> {
-    // Legacy compatibility fallback for older snap-based deployments.
-    if std::env::var("SNAP").is_err() && std::env::var("SNAP_NAME").is_err() {
-        return None;
-    }
-    let out = Command::new("snapctl")
-        .arg("get")
-        .arg("zone")
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if raw.is_empty() || raw == "null" {
-        return None;
-    }
-    let _ = Command::new("snapctl").arg("unset").arg("zone").output();
-    Some(raw)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3820,24 +3786,28 @@ mod tests {
 
     #[test]
     fn node_role_prefers_explicit_role() {
-        let mut cfg = Config::default();
-        cfg.node_role = "native_ingest".to_string();
-        cfg.node_type = Some("gateway".to_string());
+        let cfg = Config {
+            node_role: "native_ingest".to_string(),
+            ..Default::default()
+        };
         assert_eq!(resolve_node_role(&cfg), "native_ingest");
     }
 
     #[test]
-    fn node_role_uses_legacy_node_type_when_role_missing() {
-        let mut cfg = Config::default();
-        cfg.node_type = Some("browser".to_string());
-        assert_eq!(resolve_node_role(&cfg), "browser");
+    fn node_role_defaults_to_gateway_when_role_missing() {
+        let cfg = Config {
+            node_role: "".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(resolve_node_role(&cfg), "gateway");
     }
 
     #[test]
     fn node_role_defaults_to_gateway_for_invalid_inputs() {
-        let mut cfg = Config::default();
-        cfg.node_role = "".to_string();
-        cfg.node_type = Some("bad role!".to_string());
+        let cfg = Config {
+            node_role: "".to_string(),
+            ..Default::default()
+        };
         assert_eq!(resolve_node_role(&cfg), "gateway");
     }
 
@@ -3915,7 +3885,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn web_bridge_swarm_discovery_request() {
+    async fn web_bridge_swarm_record_request() {
         let (pk, sk) = nostr::generate_keypair();
         let zone = "zone-test".to_string();
         let zones = vec![zone.clone()];
@@ -4038,7 +4008,7 @@ mod tests {
             .expect("req");
 
         let payload = json!({
-            "type": "swarm_discovery_request",
+            "type": "swarm_record_request",
             "want": ["identity", "device"],
         });
         let req_ev = build_app_event(&pk, &sk, &payload).expect("app event");
@@ -4066,7 +4036,7 @@ mod tests {
                         Some(a) => a,
                         None => continue,
                     };
-                    if arr.get(0).and_then(|v| v.as_str()) != Some("EVENT") {
+                    if arr.first().and_then(|v| v.as_str()) != Some("EVENT") {
                         continue;
                     }
                     let ev_val = if arr.len() >= 3 { &arr[2] } else { &arr[1] };
@@ -4252,7 +4222,7 @@ mod tests {
                         Err(_) => continue,
                     };
                     let arr = match v.as_array() { Some(a) => a, None => continue };
-                    if arr.get(0).and_then(|v| v.as_str()) != Some("EVENT") {
+                    if arr.first().and_then(|v| v.as_str()) != Some("EVENT") {
                         continue;
                     }
                     let ev_val = if arr.len() >= 3 { &arr[2] } else { &arr[1] };
@@ -4261,12 +4231,11 @@ mod tests {
                         Ok(v) => v,
                         Err(_) => continue,
                     };
-                    if payload.get("type").and_then(|v| v.as_str()) == Some("swarm_identity_record") {
-                        if payload.get("requestId").and_then(|v| v.as_str()) == Some("req-42") {
+                    if payload.get("type").and_then(|v| v.as_str()) == Some("swarm_identity_record")
+                        && payload.get("requestId").and_then(|v| v.as_str()) == Some("req-42") {
                             got_identity = true;
                             break;
                         }
-                    }
                 }
             }
         }
@@ -4411,7 +4380,7 @@ mod tests {
                         Err(_) => continue,
                     };
                     let arr = match v.as_array() { Some(a) => a, None => continue };
-                    if arr.get(0).and_then(|v| v.as_str()) != Some("EVENT") {
+                    if arr.first().and_then(|v| v.as_str()) != Some("EVENT") {
                         continue;
                     }
                     let ev_val = if arr.len() >= 3 { &arr[2] } else { &arr[1] };

--- a/src/managed.rs
+++ b/src/managed.rs
@@ -131,7 +131,11 @@ pub(super) fn gateway_offer_candidates(payload: &Value) -> Value {
         }
     };
     push_array(payload.get("candidates"));
-    push_array(payload.get("offer").and_then(|value| value.get("candidates")));
+    push_array(
+        payload
+            .get("offer")
+            .and_then(|value| value.get("candidates")),
+    );
     Value::Array(items)
 }
 
@@ -307,7 +311,10 @@ async fn load_hosted_nvr_service_from_manifest(
     })
 }
 
-async fn load_hosted_nvr_service(client: &HttpClient, gateway_pk: &str) -> Option<HostedNvrService> {
+async fn load_hosted_nvr_service(
+    client: &HttpClient,
+    gateway_pk: &str,
+) -> Option<HostedNvrService> {
     for path in nvr_manifest_candidates() {
         let raw = match fs::read_to_string(&path) {
             Ok(raw) => raw,
@@ -317,7 +324,9 @@ async fn load_hosted_nvr_service(client: &HttpClient, gateway_pk: &str) -> Optio
             Ok(manifest) => manifest,
             Err(_) => continue,
         };
-        if let Some(service) = load_hosted_nvr_service_from_manifest(client, gateway_pk, &manifest).await {
+        if let Some(service) =
+            load_hosted_nvr_service_from_manifest(client, gateway_pk, &manifest).await
+        {
             return Some(service);
         }
     }
@@ -511,7 +520,9 @@ fn build_managed_launch_token(
     Ok(serde_json::to_string(&ev)?)
 }
 
-fn parse_managed_launch_token(token: &str) -> Result<(nostr::NostrEvent, ManagedLaunchTokenPayload)> {
+fn parse_managed_launch_token(
+    token: &str,
+) -> Result<(nostr::NostrEvent, ManagedLaunchTokenPayload)> {
     let ev: nostr::NostrEvent = serde_json::from_str(token).context("invalid launch token json")?;
     if !nostr::verify_event(&ev)? {
         return Err(anyhow!("invalid launch token signature"));
@@ -703,7 +714,9 @@ fn build_managed_service_display(
     })
 }
 
-pub(super) fn camera_resources_from_hosted(hosted: &HostedNvrService) -> Vec<grants::CameraResource> {
+pub(super) fn camera_resources_from_hosted(
+    hosted: &HostedNvrService,
+) -> Vec<grants::CameraResource> {
     let mut resources = Vec::new();
     let mut seen = HashSet::new();
 
@@ -787,7 +800,9 @@ pub(super) async fn load_target_hosted_service(
         .await
         .ok_or_else(|| anyhow!("hosted nvr service not configured"))?;
     if !service_pk.trim().is_empty() && hosted.record.device_pk.trim() != service_pk.trim() {
-        return Err(anyhow!("requested service pk does not match hosted service"));
+        return Err(anyhow!(
+            "requested service pk does not match hosted service"
+        ));
     }
     Ok(hosted)
 }
@@ -981,8 +996,7 @@ pub(super) async fn handle_gateway_service_install_request(
     let timeout_secs = req
         .timeout_secs
         .unwrap_or(ctx.remote_service_install_timeout_secs)
-        .max(60)
-        .min(7200);
+        .clamp(60, 7200);
 
     let accepted = build_gateway_service_install_status_payload(
         &req,
@@ -1295,16 +1309,13 @@ pub(super) async fn handle_gateway_zone_sync_request(
             continue;
         }
         let name = z.name.trim().to_string();
-        if !names.contains_key(&key) {
-            names.insert(
-                key,
-                if name.is_empty() {
-                    "Joined".to_string()
-                } else {
-                    name
-                },
-            );
-        }
+        names.entry(key).or_insert_with(|| {
+            if name.is_empty() {
+                "Joined".to_string()
+            } else {
+                name
+            }
+        });
     }
 
     let zone_entries: Vec<keystore::ZoneEntry> = effective_zone_keys
@@ -1408,24 +1419,23 @@ pub(super) async fn handle_gateway_managed_launch_request(
         "received managed launch request"
     );
 
-    let publish_status =
-        |status: &str,
-         launch_token: Option<String>,
-         expires_at: Option<u64>,
-         display: Option<Value>,
-         reason: Option<String>,
-         detail: Option<String>| {
-            build_gateway_managed_launch_status_payload(
-                &req,
-                &ctx.self_pk,
-                status,
-                launch_token,
-                expires_at,
-                display,
-                reason,
-                detail,
-            )
-        };
+    let publish_status = |status: &str,
+                          launch_token: Option<String>,
+                          expires_at: Option<u64>,
+                          display: Option<Value>,
+                          reason: Option<String>,
+                          detail: Option<String>| {
+        build_gateway_managed_launch_status_payload(
+            &req,
+            &ctx.self_pk,
+            status,
+            launch_token,
+            expires_at,
+            display,
+            reason,
+            detail,
+        )
+    };
 
     if requester_pk != req.device_pk {
         let status = publish_status(
@@ -1527,7 +1537,8 @@ pub(super) async fn handle_gateway_managed_launch_request(
         issued_at,
         expires_at,
     };
-    let launch_token = match build_managed_launch_token(&ctx.self_pk, &ctx.self_sk, &token_payload) {
+    let launch_token = match build_managed_launch_token(&ctx.self_pk, &ctx.self_sk, &token_payload)
+    {
         Ok(token) => token,
         Err(err) => {
             let status = publish_status(
@@ -2069,4 +2080,3 @@ pub(super) async fn handle_gateway_signal_request(
     )
     .await;
 }
-

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -191,7 +191,7 @@ fn parse_nostr_pubkey(pk_hex: &str) -> Result<PublicKey> {
 
 fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
     let h = hex.trim();
-    if h.len() % 2 != 0 {
+    if !h.len().is_multiple_of(2) {
         return Err(anyhow!("invalid hex"));
     }
     let mut out = Vec::with_capacity(h.len() / 2);

--- a/src/swarm_store.rs
+++ b/src/swarm_store.rs
@@ -43,6 +43,7 @@ pub struct SwarmStore {
 }
 
 impl SwarmStore {
+    #[cfg(test)]
     pub fn new() -> Self {
         Self::default()
     }
@@ -151,7 +152,7 @@ fn record_type(ev: &nostr::NostrEvent) -> Option<RecordType> {
     let tags = &ev.tags;
     let has_tag = tags
         .iter()
-        .any(|t| t.get(0) == Some(&"t".to_string()) && t.get(1) == Some(&RECORD_TAG.to_string()));
+        .any(|t| t.first() == Some(&"t".to_string()) && t.get(1) == Some(&RECORD_TAG.to_string()));
     if !has_tag {
         return None;
     }
@@ -252,9 +253,7 @@ fn validate_record(ev: &nostr::NostrEvent, expected: RecordType) -> Option<Recor
             if scope.is_empty() || key.is_empty() {
                 return None;
             }
-            if payload.get("value").is_none() {
-                return None;
-            }
+            payload.get("value")?;
             let author_pk = payload
                 .get("authorPk")
                 .and_then(|v| v.as_str())
@@ -389,7 +388,7 @@ impl SwarmStoreMap {
         if key.is_empty() {
             return None;
         }
-        let store = self.stores.entry(key).or_insert_with(SwarmStore::new);
+        let store = self.stores.entry(key).or_default();
         store.put_record(ev)
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -286,6 +286,7 @@ impl UdpHandle {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn forward_record_request(
         &self,
         zone: &str,
@@ -353,8 +354,7 @@ impl UdpHandle {
                     let score = if let Some(k) = key {
                         xor_distance(&key_bytes(k), &peer_bytes(&info.device_pk))
                     } else {
-                        let zero = [0u8; 32];
-                        zero
+                        [0u8; 32]
                     };
                     Some((*addr, score))
                 })
@@ -447,7 +447,7 @@ async fn run_udp_loop(
     table: Arc<Mutex<HashMap<SocketAddr, PeerInfo>>>,
     mut outbound_rx: mpsc::UnboundedReceiver<UdpOutbound>,
 ) -> Result<()> {
-    let max_packet_bytes = cfg.max_packet_bytes.max(256).min(65507);
+    let max_packet_bytes = cfg.max_packet_bytes.clamp(256, 65507);
     let mut buf = vec![0u8; max_packet_bytes];
     let mut hello_tick = interval(cfg.handshake_interval.max(Duration::from_secs(1)));
     let mut prune_tick = interval(Duration::from_secs(5));
@@ -630,13 +630,7 @@ async fn handle_message(
                 zones: cfg.zones.clone(),
                 ts: now_ms(),
             };
-            send_message(
-                socket,
-                from,
-                &reply,
-                cfg.max_packet_bytes.max(256).min(65507),
-            )
-            .await;
+            send_message(socket, from, &reply, cfg.max_packet_bytes.clamp(256, 65507)).await;
         }
         UdpMessage::Ack {
             v,
@@ -1177,6 +1171,7 @@ impl QuicHandle {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn forward_record_request(
         &self,
         zone: &str,
@@ -1334,7 +1329,7 @@ async fn run_quic_loop(
     connections: Arc<Mutex<HashMap<SocketAddr, QuinnConnection>>>,
     mut outbound_rx: mpsc::UnboundedReceiver<UdpOutbound>,
 ) -> Result<()> {
-    let max_packet_bytes = cfg.max_packet_bytes.max(256).min(65507);
+    let max_packet_bytes = cfg.max_packet_bytes.clamp(256, 65507);
     let mut hello_tick = interval(cfg.handshake_interval.max(Duration::from_secs(1)));
     let mut prune_tick = interval(Duration::from_secs(5));
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -17,8 +17,9 @@ fn discovery_envelope_shape() {
     let (_tx, rx) = tokio::sync::watch::channel("".to_string());
     let (_metrics_tx, metrics_rx) =
         tokio::sync::watch::channel(constitute_gateway::discovery::GatewayMetrics::default());
-    let (_hosted_tx, hosted_rx) =
-        tokio::sync::watch::channel(Vec::<constitute_gateway::discovery::HostedServiceRecord>::new());
+    let (_hosted_tx, hosted_rx) = tokio::sync::watch::channel(Vec::<
+        constitute_gateway::discovery::HostedServiceRecord,
+    >::new());
     let client = constitute_gateway::discovery::DiscoveryClient::new(
         constitute_gateway::relay::RelayPool::empty(),
         record,
@@ -77,8 +78,9 @@ fn zone_presence_envelope_shape() {
     let (_tx, rx) = tokio::sync::watch::channel("".to_string());
     let (_metrics_tx, metrics_rx) =
         tokio::sync::watch::channel(constitute_gateway::discovery::GatewayMetrics::default());
-    let (_hosted_tx, hosted_rx) =
-        tokio::sync::watch::channel(Vec::<constitute_gateway::discovery::HostedServiceRecord>::new());
+    let (_hosted_tx, hosted_rx) = tokio::sync::watch::channel(Vec::<
+        constitute_gateway::discovery::HostedServiceRecord,
+    >::new());
     let client = constitute_gateway::discovery::DiscoveryClient::new(
         constitute_gateway::relay::RelayPool::empty(),
         record,


### PR DESCRIPTION
## Summary
- align gateway docs and runtime contracts with the account/gateway-ui/browser-surface split
- keep gateway as hosted-service auth/control/signaling boundary, not the account UI container
- document direct app entry, transitional launch-token semantics, and planned cryptographic service capability direction
- preserve gateway as orchestrator/projector for future security and storage capabilities

## Validation
- `cargo test --quiet`
- `cargo build --quiet`
- aggregate local build pass
- aggregate local test pass

Closes #37
