### PR TITLE
Tighten edge witness proof formatting

### DIFF
--- a/src/swarm_edge_server.rs
+++ b/src/swarm_edge_server.rs
@@ -578,7 +578,13 @@ mod tests {
             }
         });
 
-        assert!(!edge_frame_correlates_to(&unrelated.to_string(), "offer-frame"));
-        assert!(edge_frame_correlates_to(&admission.to_string(), "offer-frame"));
+        assert!(!edge_frame_correlates_to(
+            &unrelated.to_string(),
+            "offer-frame"
+        ));
+        assert!(edge_frame_correlates_to(
+            &admission.to_string(),
+            "offer-frame"
+        ));
     }
 }

--- a/tests/swarm_edge.rs
+++ b/tests/swarm_edge.rs
@@ -1212,7 +1212,10 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
         .expect("delivery text");
     let service_value: serde_json::Value = serde_json::from_str(&service_delivery).unwrap();
     assert_eq!(service_value["type"], "swarm.frame");
-    assert_eq!(service_value["frame"]["capability"], CAPABILITY_STREAM_SESSION_OFFER);
+    assert_eq!(
+        service_value["frame"]["capability"],
+        CAPABILITY_STREAM_SESSION_OFFER
+    );
 
     let member_write = browser_rx
         .next()


### PR DESCRIPTION
Normalizes edge witness test formatting as part of the route and gateway proof train. This keeps the gateway evidence path aligned with the shared runtime convergence branch.\n\nValidation: native checks and root check:all passed before branch publication.