### PR TITLE
Bound snapshot fanout and edge posture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout protocol dependency
+        run: bash scripts/ci/checkout-protocol-dependency.sh
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -34,6 +37,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Checkout protocol dependency
+        run: bash scripts/ci/checkout-protocol-dependency.sh
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout protocol dependency
+        run: bash scripts/ci/checkout-protocol-dependency.sh
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout protocol dependency
+        run: bash scripts/ci/checkout-protocol-dependency.sh
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -42,6 +45,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Checkout protocol dependency
+        run: bash scripts/ci/checkout-protocol-dependency.sh
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,6 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol.git?branch=main#4f8f1887cf01726015ceb0ab43c998e5aac58d1e"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ operator-gui = ["dep:eframe"]
 
 [dependencies]
 anyhow = "1"
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol.git", branch = "main" }
+constitute-protocol = { path = "../constitute-protocol" }
 argon2 = "0.5"
 base64 = "0.22"
 chacha20poly1305 = "0.10"

--- a/scripts/ci/checkout-protocol-dependency.sh
+++ b/scripts/ci/checkout-protocol-dependency.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_url="${CONSTITUTE_PROTOCOL_REPO:-https://github.com/Aux0x7F/constitute-protocol.git}"
+target="${CONSTITUTE_PROTOCOL_PATH:-../constitute-protocol}"
+ref="${CONSTITUTE_PROTOCOL_REF:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-main}}}"
+fallback_ref="${CONSTITUTE_PROTOCOL_FALLBACK_REF:-main}"
+
+if [ -d "$target/.git" ] && [ "${GITHUB_ACTIONS:-}" != "true" ] && [ "${CONSTITUTE_PROTOCOL_ALLOW_REPLACE:-}" != "1" ]; then
+  echo "Refusing to replace existing git checkout at '$target' outside GitHub Actions." >&2
+  echo "Set CONSTITUTE_PROTOCOL_PATH to an ignored temp path or CONSTITUTE_PROTOCOL_ALLOW_REPLACE=1." >&2
+  exit 2
+fi
+
+rm -rf "$target"
+
+if git ls-remote --exit-code --heads "$repo_url" "$ref" >/dev/null 2>&1; then
+  git clone --depth 1 --branch "$ref" "$repo_url" "$target"
+elif [ "$ref" != "$fallback_ref" ] && git ls-remote --exit-code --heads "$repo_url" "$fallback_ref" >/dev/null 2>&1; then
+  git clone --depth 1 --branch "$fallback_ref" "$repo_url" "$target"
+else
+  echo "No constitute-protocol branch found for '$ref' or fallback '$fallback_ref'." >&2
+  exit 1
+fi

--- a/src/logging_surface.rs
+++ b/src/logging_surface.rs
@@ -48,6 +48,7 @@ pub async fn submit_safe_event(
         tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
         safe_facts,
         detail_ref: None,
+        encrypted_detail_refs: Vec::new(),
         redaction: vec![LogRedactionClass::Safe],
     };
     event.event_id = match log_event_id(&event) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1062,27 +1062,45 @@ async fn main() -> Result<()> {
     let hosted_services_self_sk = cfg.nostr_sk_hex.clone();
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(Duration::from_secs(10));
+        let hosted_services_materialization_floor = Duration::from_secs(60);
+        let mut hosted_services_last_fingerprint = String::new();
+        let mut hosted_services_last_published_at =
+            Instant::now() - hosted_services_materialization_floor;
         loop {
             ticker.tick().await;
-            let snapshot = managed::load_hosted_services_snapshot(
+            let bounded_hosted_services_snapshot = managed::load_hosted_services_snapshot(
                 &hosted_services_client,
                 &hosted_services_gateway_pk,
             )
             .await;
-            if hosted_services_tx.send(snapshot.clone()).is_err() {
-                break;
+            let hosted_services_fingerprint =
+                serde_json::to_string(&bounded_hosted_services_snapshot).unwrap_or_default();
+            let hosted_services_changed =
+                hosted_services_fingerprint != hosted_services_last_fingerprint;
+            let hosted_services_floor_elapsed = hosted_services_last_published_at.elapsed()
+                >= hosted_services_materialization_floor;
+            if !hosted_services_changed && !hosted_services_floor_elapsed {
+                continue;
             }
             publish_current_device_record(
                 &hosted_services_self_pk,
                 &hosted_services_self_sk,
                 &hosted_services_device_record,
-                &snapshot,
+                &bounded_hosted_services_snapshot,
                 &hosted_services_zones,
                 &hosted_services_store,
                 &hosted_services_relay_pool,
                 &hosted_services_local_relay,
             )
             .await;
+            hosted_services_last_fingerprint = hosted_services_fingerprint;
+            hosted_services_last_published_at = Instant::now();
+            if hosted_services_tx
+                .send(bounded_hosted_services_snapshot)
+                .is_err()
+            {
+                break;
+            }
         }
     });
 

--- a/src/managed.rs
+++ b/src/managed.rs
@@ -750,7 +750,7 @@ fn storage_capabilities(manifest: &HostedStorageManifest) -> Value {
             "encrypted_index_shards",
             "key_grants",
             "pin_leases",
-            "surface.app.distribution.pin",
+            constitute_protocol::CAPABILITY_SURFACE_APP_DISTRIBUTION_PIN,
             "prune",
             "local_search",
             "watch"
@@ -2132,6 +2132,7 @@ mod tests {
             .as_array()
             .expect("capability array")
             .iter()
-            .any(|value| value.as_str() == Some("surface.app.distribution.pin")));
+            .any(|value| value.as_str()
+                == Some(constitute_protocol::CAPABILITY_SURFACE_APP_DISTRIBUTION_PIN)));
     }
 }

--- a/src/swarm_edge.rs
+++ b/src/swarm_edge.rs
@@ -3,6 +3,7 @@
 //! This module is intentionally transport-neutral. HTTP, WebSocket, Nostr, UDP,
 //! and QUIC callers can adapt bytes into protocol records, but swarm frames are
 //! the semantic runtime boundary handled here.
+// domain-owned-vocabulary: swarm.directory swarm.directory.live swarm.route
 
 use anyhow::{anyhow, Result};
 use constitute_protocol::{
@@ -887,11 +888,11 @@ impl SwarmEdgeCore {
             correlation_id: Some(source.frame_id.clone()),
             channel_id: Some("swarm.route".to_string()),
             record_ref: Some(SwarmRecordRef {
-                kind: "route.observation".to_string(),
+                kind: constitute_protocol::RECORD_ROUTE_OBSERVATION.to_string(),
                 id: observation.observation_id.clone(),
                 revision: Some(now),
             }),
-            capability: Some("route.observation.publish".to_string()),
+            capability: Some(constitute_protocol::CAPABILITY_ROUTE_OBSERVATION_PUBLISH.to_string()),
             body: SwarmFrameBody {
                 encoding: "caac".to_string(),
                 envelope: Some(json!({
@@ -1244,7 +1245,7 @@ impl SwarmEdgeHub {
                         "kind": "edge",
                         "displayName": channel_id,
                         "capabilities": capability_refs,
-                        "recordKinds": ["swarm.frame"],
+                        "recordKinds": [constitute_protocol::SWARM_WIRE_FRAME],
                         "ownerRefs": [member_ref],
                         "policyRef": policy_id,
                         "createdAt": now,

--- a/src/swarm_edge.rs
+++ b/src/swarm_edge.rs
@@ -573,6 +573,8 @@ pub struct ProjectionBridge {
     pub channel_id: Option<String>,
     pub projection_ref: Option<String>,
     pub delta: bool,
+    pub materialization_budget_ref: Option<String>,
+    pub consumer_floor_ref: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -604,6 +606,14 @@ pub fn bridge_service_frame(frame: &SwarmFrame) -> Option<ServiceBridgeRecord> {
                 channel_id: frame.channel_id.clone(),
                 projection_ref: frame.record_ref.as_ref().map(|record| record.id.clone()),
                 delta: matches!(frame.kind, SwarmFrameKind::ProjectionDelta),
+                materialization_budget_ref: frame
+                    .channel_id
+                    .as_ref()
+                    .map(|channel| format!("materialization:gateway:{channel}:bridge")),
+                consumer_floor_ref: frame
+                    .channel_id
+                    .as_ref()
+                    .map(|channel| format!("consumer-floor:gateway:{channel}:service-bridge")),
             }))
         }
         SwarmFrameKind::StoragePinIntent | SwarmFrameKind::StoragePinAttestation => {

--- a/src/swarm_edge_server.rs
+++ b/src/swarm_edge_server.rs
@@ -2,6 +2,7 @@
 //!
 //! The wire protocol accepts only edge control records and `SwarmFrame` records.
 //! Service semantics stay inside attached edge members.
+// domain-owned-vocabulary: swarm.directory
 
 use anyhow::{anyhow, Context, Result};
 use constitute_protocol::{
@@ -147,7 +148,7 @@ async fn handle_client(
                     }
                     continue;
                 };
-                if matches!(edge_record_type(&text).as_deref(), Some("swarm.frame")) {
+                if matches!(edge_record_type(&text).as_deref(), Some(constitute_protocol::SWARM_WIRE_FRAME)) {
                     if let Some(pending) = pending_read_witness.as_ref() {
                         if edge_frame_correlates_to(&text, &pending.frame_id) {
                             let pending = pending_read_witness.take().expect("pending witness exists");
@@ -209,7 +210,7 @@ async fn handle_client(
                             break;
                         }
                         let outbound = json!({
-                            "type": "swarm.frame",
+                            "type": constitute_protocol::SWARM_WIRE_FRAME,
                             "frame": delivery.frame,
                         });
                         match timeout(
@@ -291,7 +292,7 @@ async fn handle_wire_message(
         .unwrap_or_default()
         .trim();
     match record_type {
-        "swarm.edge.hello" => {
+        constitute_protocol::SWARM_EDGE_WIRE_HELLO => {
             let hello: SwarmEdgeHello = match parse_record_field(&value, "hello") {
                 Ok(hello) => hello,
                 Err(err) => return Some(reject_value("invalid_hello", err, None)),
@@ -304,16 +305,17 @@ async fn handle_wire_message(
                     *member_ref = attach.session.member_ref.clone();
                     *member_kind = Some(kind);
                     Some(json!({
-                        "type": "swarm.edge.accept",
+                        "type": constitute_protocol::SWARM_EDGE_WIRE_ACCEPT,
                         "accept": attach.accept,
                     }))
                 }
-                SwarmEdgeAttachResult::Rejected(reject) => {
-                    Some(reject_wire_value("swarm.edge.reject", reject))
-                }
+                SwarmEdgeAttachResult::Rejected(reject) => Some(reject_wire_value(
+                    constitute_protocol::SWARM_EDGE_WIRE_REJECT,
+                    reject,
+                )),
             }
         }
-        "swarm.edge.resume" => {
+        constitute_protocol::SWARM_EDGE_WIRE_RESUME => {
             let resume: SwarmEdgeResume = match parse_record_field(&value, "resume") {
                 Ok(resume) => resume,
                 Err(err) => return Some(reject_value("invalid_resume", err, None)),
@@ -328,18 +330,19 @@ async fn handle_wire_message(
                     *member_ref = session.member_ref.clone();
                     *member_kind = Some(kind);
                     Some(json!({
-                        "type": "swarm.edge.accept",
+                        "type": constitute_protocol::SWARM_EDGE_WIRE_ACCEPT,
                         "sessionId": session.session_id,
                         "accept": accept,
                         "session": session,
                     }))
                 }
-                SwarmEdgeResumeResult::Rejected(reject) => {
-                    Some(reject_wire_value("swarm.edge.reject", reject))
-                }
+                SwarmEdgeResumeResult::Rejected(reject) => Some(reject_wire_value(
+                    constitute_protocol::SWARM_EDGE_WIRE_REJECT,
+                    reject,
+                )),
             }
         }
-        "swarm.frame" => {
+        constitute_protocol::SWARM_WIRE_FRAME => {
             if session_id.trim().is_empty() {
                 return Some(reject_value(
                     "missing_session",
@@ -379,7 +382,7 @@ async fn handle_wire_message(
                         });
                     }
                     Some(json!({
-                        "type": "swarm.frame",
+                        "type": constitute_protocol::SWARM_WIRE_FRAME,
                         "frame": receipt.response,
                         "propagation": receipt.propagation,
                         "routeObservations": receipt.route_observations,
@@ -387,9 +390,10 @@ async fn handle_wire_message(
                         "bridge": receipt.bridge,
                     }))
                 }
-                SwarmEdgeIngressResult::Rejected(reject) => {
-                    Some(reject_wire_value("swarm.edge.reject", reject))
-                }
+                SwarmEdgeIngressResult::Rejected(reject) => Some(reject_wire_value(
+                    constitute_protocol::SWARM_EDGE_WIRE_REJECT,
+                    reject,
+                )),
             }
         }
         other => Some(reject_value(
@@ -494,7 +498,7 @@ fn edge_member_kind(value: &str) -> SwarmEdgeMemberKind {
 
 fn reject_value(reason_code: &str, err: anyhow::Error, correlation_id: Option<String>) -> Value {
     reject_wire_value(
-        "swarm.edge.reject",
+        constitute_protocol::SWARM_EDGE_WIRE_REJECT,
         SwarmEdgeReject {
             reason_code: reason_code.to_string(),
             detail: err.to_string(),
@@ -556,7 +560,7 @@ mod tests {
             CAPABILITY_MEDIA_STREAM_PREVIEW
         ))));
         assert!(!frame_requires_member_read_witness(&test_frame(Some(
-            "stream.session.answer"
+            constitute_protocol::RECORD_STREAM_SESSION_ANSWER
         ))));
         assert!(!frame_requires_member_read_witness(&test_frame(None)));
     }
@@ -564,14 +568,14 @@ mod tests {
     #[test]
     fn edge_frame_witness_requires_matching_correlation() {
         let unrelated = json!({
-            "type": "swarm.frame",
+            "type": constitute_protocol::SWARM_WIRE_FRAME,
             "frame": {
                 "frameId": "projection-frame",
                 "correlationId": "projection-repair"
             }
         });
         let admission = json!({
-            "type": "swarm.frame",
+            "type": constitute_protocol::SWARM_WIRE_FRAME,
             "frame": {
                 "frameId": "admission-frame",
                 "correlationId": "offer-frame"

--- a/tests/swarm_edge.rs
+++ b/tests/swarm_edge.rs
@@ -168,7 +168,7 @@ fn harness() -> (SwarmEdgeCore, String) {
         SwarmRouteMember {
             member_ref: WRONG_CHANNEL_PK.to_string(),
             zone_id: "zone-a".to_string(),
-            channel_ids: vec!["logging.events".to_string()],
+            channel_ids: vec![constitute_protocol::PROJECTION_CHANNEL_LOGGING_EVENTS.to_string()],
             audience_refs: vec![SERVICE_REF.to_string()],
             capabilities: vec![CAPABILITY_SERVICE_INTENT_INVOKE.to_string()],
             interested: true,
@@ -179,7 +179,7 @@ fn harness() -> (SwarmEdgeCore, String) {
             zone_id: "zone-a".to_string(),
             channel_ids: vec!["nvr.control".to_string()],
             audience_refs: vec![SERVICE_REF.to_string()],
-            capabilities: vec!["projection.observe".to_string()],
+            capabilities: vec![constitute_protocol::CAPABILITY_PROJECTION_OBSERVE.to_string()],
             interested: true,
             replicator: false,
         },
@@ -313,7 +313,7 @@ fn planner_returns_only_authorized_members_and_respects_hop_budget() {
             .record_ref
             .as_ref()
             .map(|record| record.kind.as_str()),
-        Some("route.observation")
+        Some(constitute_protocol::RECORD_ROUTE_OBSERVATION)
     );
 
     let mut exhausted_frame = valid_frame("frame-plan-ttl", "nonce-plan-ttl");
@@ -449,7 +449,7 @@ fn service_projection_and_storage_frames_emit_adapter_bridge_records() {
     let mut projection = valid_frame("projection", "nonce-projection");
     projection.kind = SwarmFrameKind::ProjectionDelta;
     projection.record_ref = Some(SwarmRecordRef {
-        kind: "projection.delta".to_string(),
+        kind: constitute_protocol::RECORD_PROJECTION_DELTA.to_string(),
         id: "nvr.status".to_string(),
         revision: Some(7),
     });
@@ -466,7 +466,7 @@ fn service_projection_and_storage_frames_emit_adapter_bridge_records() {
     let mut storage = valid_frame("pin", "nonce-pin");
     storage.kind = SwarmFrameKind::StoragePinIntent;
     storage.record_ref = Some(SwarmRecordRef {
-        kind: "storage.pin.intent".to_string(),
+        kind: constitute_protocol::RECORD_STORAGE_PIN_INTENT.to_string(),
         id: "pin-1".to_string(),
         revision: None,
     });
@@ -757,13 +757,14 @@ fn service_edge_member_routes_by_typed_service_pk_for_namespaced_member_ref() {
         CAPABILITY_SWARM_EDGE_ATTACH.to_string(),
         CAPABILITY_SERVICE_INTENT_INVOKE.to_string(),
     ];
-    service_hello.channel_refs = vec!["logging.events".to_string()];
+    service_hello.channel_refs =
+        vec![constitute_protocol::PROJECTION_CHANNEL_LOGGING_EVENTS.to_string()];
     match hub.attach_member(SwarmEdgeMemberKind::Service, service_hello, NOW) {
         SwarmEdgeAttachResult::Accepted(_) => {}
         SwarmEdgeAttachResult::Rejected(reject) => panic!("service attach rejected: {reject:?}"),
     };
     let mut frame = valid_frame("namespaced-service-pk", "namespaced-service-pk-nonce");
-    frame.channel_id = Some("logging.events".to_string());
+    frame.channel_id = Some(constitute_protocol::PROJECTION_CHANNEL_LOGGING_EVENTS.to_string());
     frame.audience = json!({ "servicePk": LOGGING_SERVICE_PK });
     refresh_frame_id(&mut frame);
 
@@ -872,7 +873,8 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .push(CAPABILITY_SERVICE_INTENT_INVOKE.to_string());
     service_tx
         .send(Message::Text(
-            json!({ "type": "swarm.edge.hello", "hello": service_hello }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_EDGE_WIRE_HELLO, "hello": service_hello })
+                .to_string(),
         ))
         .await
         .expect("service hello");
@@ -884,7 +886,10 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .into_text()
         .expect("service text");
     let service_accept_value = serde_json::from_str::<serde_json::Value>(&service_accept).unwrap();
-    assert_eq!(service_accept_value["type"], "swarm.edge.accept");
+    assert_eq!(
+        service_accept_value["type"],
+        constitute_protocol::SWARM_EDGE_WIRE_ACCEPT
+    );
     let service_accept_record: SwarmEdgeAccept =
         serde_json::from_value(service_accept_value["accept"].clone()).expect("service accept");
     let service_resume_issued_at = now_ms();
@@ -905,7 +910,7 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
     };
     service_tx
         .send(Message::Text(
-            json!({ "type": "swarm.edge.resume", "resume": service_resume }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_EDGE_WIRE_RESUME, "resume": service_resume }).to_string(),
         ))
         .await
         .expect("service resume");
@@ -918,7 +923,10 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .expect("service resume text");
     let service_resume_accept_value =
         serde_json::from_str::<serde_json::Value>(&service_resume_accept).unwrap();
-    assert_eq!(service_resume_accept_value["type"], "swarm.edge.accept");
+    assert_eq!(
+        service_resume_accept_value["type"],
+        constitute_protocol::SWARM_EDGE_WIRE_ACCEPT
+    );
     assert!(service_resume_accept_value.get("accept").is_some());
     assert!(service_resume_accept_value.get("session").is_some());
     assert_eq!(
@@ -934,7 +942,8 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
     browser_hello.expires_at = Some(browser_issued_at + 60_000);
     browser_tx
         .send(Message::Text(
-            json!({ "type": "swarm.edge.hello", "hello": browser_hello }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_EDGE_WIRE_HELLO, "hello": browser_hello })
+                .to_string(),
         ))
         .await
         .expect("browser hello");
@@ -947,7 +956,7 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .expect("browser text");
     assert_eq!(
         serde_json::from_str::<serde_json::Value>(&browser_accept).unwrap()["type"],
-        "swarm.edge.accept"
+        constitute_protocol::SWARM_EDGE_WIRE_ACCEPT
     );
 
     let mut directory_frame = valid_frame("live-directory", "live-directory-nonce");
@@ -966,7 +975,8 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
     refresh_frame_id(&mut directory_frame);
     browser_tx
         .send(Message::Text(
-            json!({ "type": "swarm.frame", "frame": directory_frame }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_WIRE_FRAME, "frame": directory_frame })
+                .to_string(),
         ))
         .await
         .expect("send directory observe");
@@ -990,10 +1000,13 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .expect("directory route observation text");
     let directory_observation_value: serde_json::Value =
         serde_json::from_str(&directory_observation).unwrap();
-    assert_eq!(directory_observation_value["type"], "swarm.frame");
+    assert_eq!(
+        directory_observation_value["type"],
+        constitute_protocol::SWARM_WIRE_FRAME
+    );
     assert_eq!(
         directory_observation_value["frame"]["recordRef"]["kind"],
-        "route.observation"
+        constitute_protocol::RECORD_ROUTE_OBSERVATION
     );
     let directory_delivery = browser_rx
         .next()
@@ -1003,7 +1016,10 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .into_text()
         .expect("directory delivery text");
     let directory_value: serde_json::Value = serde_json::from_str(&directory_delivery).unwrap();
-    assert_eq!(directory_value["type"], "swarm.frame");
+    assert_eq!(
+        directory_value["type"],
+        constitute_protocol::SWARM_WIRE_FRAME
+    );
     assert_eq!(directory_value["frame"]["kind"], "bootstrap.gatewayHint");
     assert_eq!(
         directory_value["frame"]["body"]["encoding"], "public",
@@ -1034,7 +1050,7 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
 
     browser_tx
         .send(Message::Text(
-            json!({ "type": "swarm.frame", "frame": frame }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_WIRE_FRAME, "frame": frame }).to_string(),
         ))
         .await
         .expect("send frame");
@@ -1057,10 +1073,13 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .into_text()
         .expect("route observation text");
     let route_selected_value: serde_json::Value = serde_json::from_str(&route_selected).unwrap();
-    assert_eq!(route_selected_value["type"], "swarm.frame");
+    assert_eq!(
+        route_selected_value["type"],
+        constitute_protocol::SWARM_WIRE_FRAME
+    );
     assert_eq!(
         route_selected_value["frame"]["recordRef"]["kind"],
-        "route.observation"
+        constitute_protocol::RECORD_ROUTE_OBSERVATION
     );
 
     let service_delivery = service_rx
@@ -1071,7 +1090,7 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .into_text()
         .expect("delivery text");
     let value: serde_json::Value = serde_json::from_str(&service_delivery).unwrap();
-    assert_eq!(value["type"], "swarm.frame");
+    assert_eq!(value["type"], constitute_protocol::SWARM_WIRE_FRAME);
     assert_eq!(value["frame"]["kind"], "service.intent");
     assert_eq!(value["frame"]["audience"]["serviceRef"], SERVICE_REF);
     let member_write = browser_rx
@@ -1082,10 +1101,13 @@ async fn live_swarm_edge_socket_attaches_members_and_routes_frames() {
         .into_text()
         .expect("member write observation text");
     let member_write_value: serde_json::Value = serde_json::from_str(&member_write).unwrap();
-    assert_eq!(member_write_value["type"], "swarm.frame");
+    assert_eq!(
+        member_write_value["type"],
+        constitute_protocol::SWARM_WIRE_FRAME
+    );
     assert_eq!(
         member_write_value["frame"]["recordRef"]["kind"],
-        "route.observation"
+        constitute_protocol::RECORD_ROUTE_OBSERVATION
     );
     assert_eq!(
         member_write_value["frame"]["body"]["payload"]["record"]["state"],
@@ -1123,7 +1145,8 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
         .push(CAPABILITY_MEDIA_STREAM_PREVIEW.to_string());
     service_tx
         .send(Message::Text(
-            json!({ "type": "swarm.edge.hello", "hello": service_hello }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_EDGE_WIRE_HELLO, "hello": service_hello })
+                .to_string(),
         ))
         .await
         .expect("service hello");
@@ -1136,7 +1159,7 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
         .expect("service text");
     assert_eq!(
         serde_json::from_str::<serde_json::Value>(&service_accept).unwrap()["type"],
-        "swarm.edge.accept"
+        constitute_protocol::SWARM_EDGE_WIRE_ACCEPT
     );
 
     let (browser_ws, _) = connect_async(&url).await.expect("browser connect");
@@ -1148,7 +1171,8 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
     browser_hello.channel_refs.push("nvr.streams".to_string());
     browser_tx
         .send(Message::Text(
-            json!({ "type": "swarm.edge.hello", "hello": browser_hello }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_EDGE_WIRE_HELLO, "hello": browser_hello })
+                .to_string(),
         ))
         .await
         .expect("browser hello");
@@ -1161,7 +1185,7 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
         .expect("browser text");
     assert_eq!(
         serde_json::from_str::<serde_json::Value>(&browser_accept).unwrap()["type"],
-        "swarm.edge.accept"
+        constitute_protocol::SWARM_EDGE_WIRE_ACCEPT
     );
 
     let issued_at = now_ms();
@@ -1172,7 +1196,7 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
     frame.expires_at = Some(issued_at + 60_000);
     frame.channel_id = Some("nvr.streams".to_string());
     frame.record_ref = Some(SwarmRecordRef {
-        kind: "stream.session.offer".to_string(),
+        kind: constitute_protocol::RECORD_STREAM_SESSION_OFFER.to_string(),
         id: "silent-stream-offer".to_string(),
         revision: None,
     });
@@ -1181,7 +1205,7 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
 
     browser_tx
         .send(Message::Text(
-            json!({ "type": "swarm.frame", "frame": frame }).to_string(),
+            json!({ "type": constitute_protocol::SWARM_WIRE_FRAME, "frame": frame }).to_string(),
         ))
         .await
         .expect("send stream frame");
@@ -1211,7 +1235,7 @@ async fn live_swarm_edge_closes_silent_stream_member_after_write_witness_timeout
         .into_text()
         .expect("delivery text");
     let service_value: serde_json::Value = serde_json::from_str(&service_delivery).unwrap();
-    assert_eq!(service_value["type"], "swarm.frame");
+    assert_eq!(service_value["type"], constitute_protocol::SWARM_WIRE_FRAME);
     assert_eq!(
         service_value["frame"]["capability"],
         CAPABILITY_STREAM_SESSION_OFFER


### PR DESCRIPTION
## Summary
- bound runtime/gateway snapshot fanout and edge adapter posture
- add logging and managed-service updates for safer substrate participation
- keep gateway focused on edge, route, service inventory, and transport evidence

## Validation
- Release-train checks to run after the full dependency train is opened.