### PR TITLE
Add gateway association contribution posture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=main#433f54397fdee6f5619f9de408b4a307143a0191"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -1067,6 +1068,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=main#e0db94216f0a57bf427086f225156db4625717cd"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "constitute-fabric"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "constitute-protocol",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "constitute-gateway"
 version = "0.1.3"
 dependencies = [
@@ -1030,6 +1040,7 @@ dependencies = [
  "cbc",
  "chacha20poly1305",
  "clap",
+ "constitute-fabric",
  "constitute-protocol",
  "eframe",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ operator-gui = ["dep:eframe"]
 
 [dependencies]
 anyhow = "1"
+constitute-fabric = { path = "../constitute-fabric" }
 constitute-protocol = { path = "../constitute-protocol" }
 argon2 = "0.5"
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ operator-gui = ["dep:eframe"]
 
 [dependencies]
 anyhow = "1"
-constitute-fabric = { path = "../constitute-fabric" }
-constitute-protocol = { path = "../constitute-protocol" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "main" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "main" }
 argon2 = "0.5"
 base64 = "0.22"
 chacha20poly1305 = "0.10"

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ swarm edge hub.
 Gateway owns edge admission, route observations, and attached-session directory
 truth. It routes and attests generic frames without owning NVR media semantics,
 Logging query semantics, Storage object semantics, or identity authority.
+
+Gateway discovery records include validated association posture: substrate
+initial handoff, association-boundary proof, gateway association contribution,
+lifecycle plan, and host-fabric fulfillment plan. The boundary proof keeps
+initial owner/host association, ongoing gateway association, route association,
+service presence, and membership as separate refs.

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -6,15 +6,16 @@
 use anyhow::Result;
 use constitute_fabric::{reduce_host_fabric, HostFabricReductionInput, HostFabricRoleRequirement};
 use constitute_protocol::{
-    validate_host_fabric_member_contribution, validate_lifecycle_plan_posture,
-    validate_substrate_association_handoff, HostFabricFulfillmentPlan,
-    HostFabricMemberContribution, LifecyclePhasePosture, LifecyclePlanPosture,
-    SubstrateAssociationHandoff, FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF,
+    validate_association_boundary_proof, validate_host_fabric_member_contribution,
+    validate_lifecycle_plan_posture, validate_substrate_association_handoff,
+    AssociationBoundaryProof, HostFabricFulfillmentPlan, HostFabricMemberContribution,
+    LifecyclePhasePosture, LifecyclePlanPosture, SubstrateAssociationHandoff,
+    FABRIC_ASSOCIATION_BOUNDARY_PROOF_READY, FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF,
     FABRIC_LIFECYCLE_PHASE_OBSERVE, FABRIC_LIFECYCLE_PHASE_READY, FABRIC_LIFECYCLE_PHASE_RUN,
     FABRIC_LIFECYCLE_PHASE_RUNNING, FABRIC_LIFECYCLE_PHASE_SOURCE, FABRIC_LIFECYCLE_PLAN_READY,
     FABRIC_MEMBER_CONTRIBUTION_RUNNING, FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION,
-    RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION, RECORD_LIFECYCLE_PLAN_POSTURE,
-    RECORD_SUBSTRATE_ASSOCIATION_HANDOFF,
+    RECORD_ASSOCIATION_BOUNDARY_PROOF, RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION,
+    RECORD_LIFECYCLE_PLAN_POSTURE, RECORD_SUBSTRATE_ASSOCIATION_HANDOFF,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -36,6 +37,7 @@ const RECORD_TTL_MS: u64 = 24 * 60 * 60 * 1000;
 #[serde(rename_all = "camelCase")]
 pub struct GatewayAssociationPosture {
     pub substrate_association_handoff: SubstrateAssociationHandoff,
+    pub association_boundary_proof: AssociationBoundaryProof,
     pub gateway_association_contribution: HostFabricMemberContribution,
     pub lifecycle_plan: LifecyclePlanPosture,
     pub fulfillment_plan: HostFabricFulfillmentPlan,
@@ -564,8 +566,8 @@ pub fn gateway_association_posture(
             "fabric-plan:gateway-association:{}",
             short_ref(&record.device_pk)
         ),
-        fabric_ref,
-        host_ref,
+        fabric_ref: fabric_ref.clone(),
+        host_ref: host_ref.clone(),
         contract_ref: "contract:gateway-association@0.1.0".to_string(),
         required_roles: vec![HostFabricRoleRequirement {
             role_ref: format!("role:{FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION}"),
@@ -583,8 +585,49 @@ pub fn gateway_association_posture(
     })?
     .fulfillment_plan;
 
+    let association_boundary_proof = AssociationBoundaryProof {
+        kind: Some(RECORD_ASSOCIATION_BOUNDARY_PROOF.to_string()),
+        proof_id: format!(
+            "association-boundary-proof:gateway:{}",
+            short_ref(&record.device_pk)
+        ),
+        host_ref: host_ref.clone(),
+        owner_ref: record.identity_id.clone(),
+        fabric_ref: fabric_ref.clone(),
+        state: FABRIC_ASSOCIATION_BOUNDARY_PROOF_READY.to_string(),
+        substrate_handoff_ref: handoff.handoff_id.clone(),
+        initial_association_refs: handoff.initial_association_refs.clone(),
+        gateway_association_refs: handoff.gateway_association_refs.clone(),
+        route_association_refs: vec![format!(
+            "route-association:gateway:{}",
+            short_ref(&record.device_pk)
+        )],
+        service_presence_refs: vec![format!(
+            "service-presence:gateway:{}",
+            short_ref(&record.device_pk)
+        )],
+        membership_refs: vec![format!(
+            "member-presence:gateway:{}",
+            short_ref(&record.device_pk)
+        )],
+        fabric_plan_refs: vec![fulfillment_plan.plan_id.clone()],
+        evidence_refs: vec![format!(
+            "evidence:association-boundary:gateway:{}",
+            record.device_pk
+        )],
+        blocked_reasons: vec![],
+        safe_facts: json!({
+            "phaseSplit": "substrate-gateway-route-service-membership",
+            "servicePresenceSource": "gatewayDiscoveryRecord"
+        }),
+        observed_at,
+        expires_at: Some(observed_at + RECORD_TTL_MS),
+    };
+    validate_association_boundary_proof(&association_boundary_proof)?;
+
     Ok(GatewayAssociationPosture {
         substrate_association_handoff: handoff,
+        association_boundary_proof,
         gateway_association_contribution: contribution,
         lifecycle_plan,
         fulfillment_plan,
@@ -729,9 +772,31 @@ mod tests {
             posture.fulfillment_plan.association_handoff_ref,
             Some(posture.substrate_association_handoff.handoff_id.clone())
         );
+        assert_ne!(
+            posture
+                .association_boundary_proof
+                .initial_association_refs
+                .first(),
+            posture
+                .association_boundary_proof
+                .gateway_association_refs
+                .first()
+        );
+        assert_ne!(
+            posture
+                .association_boundary_proof
+                .gateway_association_refs
+                .first(),
+            posture.association_boundary_proof.membership_refs.first()
+        );
+        assert_eq!(
+            posture.association_boundary_proof.fabric_plan_refs,
+            vec![posture.fulfillment_plan.plan_id.clone()]
+        );
 
         let json = record.to_json();
         assert!(json.contains("\"gatewayAssociationPosture\""));
+        assert!(json.contains("\"association.boundary.proof\""));
         assert!(json.contains("\"hostFabric.member.contribution\""));
         assert!(json.contains("\"substrate.association.handoff\""));
     }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -4,6 +4,18 @@
 //! zone-scoped gateway presence signaling.
 
 use anyhow::Result;
+use constitute_protocol::{
+    validate_host_fabric_fulfillment_plan, validate_host_fabric_member_contribution,
+    validate_lifecycle_plan_posture, validate_substrate_association_handoff,
+    HostFabricFulfillmentPlan, HostFabricMemberContribution, LifecyclePhasePosture,
+    LifecyclePlanPosture, SubstrateAssociationHandoff, FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF,
+    FABRIC_FULFILLMENT_PLAN_READY, FABRIC_LIFECYCLE_PHASE_OBSERVE, FABRIC_LIFECYCLE_PHASE_READY,
+    FABRIC_LIFECYCLE_PHASE_RUN, FABRIC_LIFECYCLE_PHASE_RUNNING, FABRIC_LIFECYCLE_PHASE_SOURCE,
+    FABRIC_LIFECYCLE_PLAN_READY, FABRIC_MEMBER_CONTRIBUTION_RUNNING,
+    FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION, RECORD_HOST_FABRIC_FULFILLMENT_PLAN,
+    RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION, RECORD_LIFECYCLE_PLAN_POSTURE,
+    RECORD_SUBSTRATE_ASSOCIATION_HANDOFF,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::time::Duration;
@@ -19,6 +31,15 @@ const APP_KIND: u32 = 1;
 const APP_TAG: &str = "constitute";
 const SUB_ID: &str = "constitute_sub_v2";
 const RECORD_TTL_MS: u64 = 24 * 60 * 60 * 1000;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayAssociationPosture {
+    pub substrate_association_handoff: SubstrateAssociationHandoff,
+    pub gateway_association_contribution: HostFabricMemberContribution,
+    pub lifecycle_plan: LifecyclePlanPosture,
+    pub fulfillment_plan: HostFabricFulfillmentPlan,
+}
 
 pub fn relay_req_json() -> String {
     let filters = vec![
@@ -168,7 +189,7 @@ impl SwarmDeviceRecord {
     }
 
     fn as_json_value(&self) -> serde_json::Value {
-        json!({
+        let mut value = json!({
             "devicePk": self.device_pk,
             "identityId": self.identity_id,
             "deviceLabel": self.device_label,
@@ -191,7 +212,16 @@ impl SwarmDeviceRecord {
                 .iter()
                 .map(HostedServiceRecord::as_json_value)
                 .collect::<Vec<_>>(),
-        })
+        });
+        if let Ok(posture) = gateway_association_posture(self, self.updated_at) {
+            if let Some(object) = value.as_object_mut() {
+                object.insert(
+                    "gatewayAssociationPosture".to_string(),
+                    serde_json::to_value(posture).unwrap_or(Value::Null),
+                );
+            }
+        }
+        value
     }
 }
 
@@ -408,6 +438,179 @@ fn gateway_service_surface_record(record: &SwarmDeviceRecord) -> HostedServiceRe
     }
 }
 
+pub fn gateway_association_posture(
+    record: &SwarmDeviceRecord,
+    observed_at: u64,
+) -> Result<GatewayAssociationPosture> {
+    let fabric_ref = gateway_fabric_ref(record);
+    let host_ref = gateway_host_ref(record);
+    let gateway_association_ref = gateway_association_ref(record);
+    let handoff = SubstrateAssociationHandoff {
+        kind: Some(RECORD_SUBSTRATE_ASSOCIATION_HANDOFF.to_string()),
+        handoff_id: format!(
+            "handoff:gateway:{}:initial-owner",
+            short_ref(&record.device_pk)
+        ),
+        substrate_ref: "substrate:first-trust:gateway".to_string(),
+        host_ref: host_ref.clone(),
+        owner_ref: record.identity_id.clone(),
+        fabric_ref: fabric_ref.clone(),
+        state: FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF.to_string(),
+        initial_association_refs: vec![format!(
+            "association:substrate:{}:{}",
+            record.identity_id,
+            short_ref(&record.device_pk)
+        )],
+        gateway_association_refs: vec![gateway_association_ref.clone()],
+        evidence_refs: vec![format!("evidence:gateway-association:{}", record.device_pk)],
+        blocked_reasons: vec![],
+        safe_facts: json!({
+            "handoff": "substrate-to-gateway-association",
+            "role": record.role,
+            "hostPlatform": record.host_platform
+        }),
+        issued_at: observed_at.saturating_sub(1),
+        handed_off_at: Some(observed_at),
+        expires_at: Some(observed_at + RECORD_TTL_MS),
+    };
+    validate_substrate_association_handoff(&handoff)?;
+
+    let contribution = HostFabricMemberContribution {
+        kind: Some(RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION.to_string()),
+        contribution_id: format!(
+            "fabric-contribution:gateway-association:{}",
+            short_ref(&record.device_pk)
+        ),
+        fabric_ref: fabric_ref.clone(),
+        host_ref: host_ref.clone(),
+        member_ref: record.device_pk.clone(),
+        role: FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION.to_string(),
+        state: FABRIC_MEMBER_CONTRIBUTION_RUNNING.to_string(),
+        contract_ref: "contract:gateway-association@0.1.0".to_string(),
+        subject_ref: gateway_association_ref.clone(),
+        capability_refs: vec!["gateway.association.fulfill".to_string()],
+        grant_refs: vec![format!("grant:gateway-association:{}", record.identity_id)],
+        input_refs: vec![handoff.handoff_id.clone()],
+        output_refs: vec![format!(
+            "projection:gateway-association:{}",
+            record.device_pk
+        )],
+        evidence_refs: vec![format!("evidence:gateway-presence:{}", record.device_pk)],
+        lifecycle_plan_refs: vec![format!(
+            "lifecycle-plan:gateway-association:{}",
+            short_ref(&record.device_pk)
+        )],
+        release_refs: vec![format!("release:gateway:{}", record.service_version)],
+        resource_posture: None,
+        blocked_reasons: vec![],
+        safe_facts: json!({
+            "role": FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION,
+            "serviceVersion": record.service_version,
+            "releaseTrack": record.release_track
+        }),
+        observed_at,
+        expires_at: Some(observed_at + RECORD_TTL_MS),
+    };
+    validate_host_fabric_member_contribution(&contribution)?;
+
+    let lifecycle_plan = LifecyclePlanPosture {
+        kind: Some(RECORD_LIFECYCLE_PLAN_POSTURE.to_string()),
+        lifecycle_plan_id: contribution.lifecycle_plan_refs[0].clone(),
+        subject_ref: gateway_association_ref.clone(),
+        contract_ref: "contract:lifecycle.gateway-association@0.1.0".to_string(),
+        state: FABRIC_LIFECYCLE_PLAN_READY.to_string(),
+        lifecycle_contract_refs: vec!["contract:lifecycle.gateway-association@0.1.0".to_string()],
+        phase_postures: vec![
+            LifecyclePhasePosture {
+                phase: FABRIC_LIFECYCLE_PHASE_SOURCE.to_string(),
+                state: FABRIC_LIFECYCLE_PHASE_READY.to_string(),
+                evidence_refs: vec![format!("evidence:gateway-source:{}", record.device_pk)],
+                output_refs: vec![format!("source:gateway:{}", record.service_version)],
+                blocked_reasons: vec![],
+                safe_facts: Value::Null,
+            },
+            LifecyclePhasePosture {
+                phase: FABRIC_LIFECYCLE_PHASE_RUN.to_string(),
+                state: FABRIC_LIFECYCLE_PHASE_RUNNING.to_string(),
+                evidence_refs: vec![format!("evidence:gateway-running:{}", record.device_pk)],
+                output_refs: vec![gateway_association_ref.clone()],
+                blocked_reasons: vec![],
+                safe_facts: Value::Null,
+            },
+            LifecyclePhasePosture {
+                phase: FABRIC_LIFECYCLE_PHASE_OBSERVE.to_string(),
+                state: FABRIC_LIFECYCLE_PHASE_READY.to_string(),
+                evidence_refs: vec![format!("evidence:gateway-observed:{}", record.device_pk)],
+                output_refs: vec!["projection:gateway-association:hot".to_string()],
+                blocked_reasons: vec![],
+                safe_facts: Value::Null,
+            },
+        ],
+        member_contribution_refs: vec![contribution.contribution_id.clone()],
+        evidence_refs: vec![format!(
+            "evidence:lifecycle:gateway-association:{}",
+            record.device_pk
+        )],
+        release_refs: contribution.release_refs.clone(),
+        blocked_reasons: vec![],
+        safe_facts: Value::Null,
+        observed_at,
+        expires_at: Some(observed_at + RECORD_TTL_MS),
+    };
+    validate_lifecycle_plan_posture(&lifecycle_plan)?;
+
+    let fulfillment_plan = HostFabricFulfillmentPlan {
+        kind: Some(RECORD_HOST_FABRIC_FULFILLMENT_PLAN.to_string()),
+        plan_id: format!(
+            "fabric-plan:gateway-association:{}",
+            short_ref(&record.device_pk)
+        ),
+        fabric_ref,
+        host_ref,
+        contract_ref: "contract:gateway-association@0.1.0".to_string(),
+        state: FABRIC_FULFILLMENT_PLAN_READY.to_string(),
+        required_role_refs: vec![format!("role:{FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION}")],
+        member_contribution_refs: vec![contribution.contribution_id.clone()],
+        missing_role_refs: vec![],
+        lifecycle_plan_refs: vec![lifecycle_plan.lifecycle_plan_id.clone()],
+        materialization_budget_refs: vec!["materialization-budget:gateway-association".to_string()],
+        association_handoff_ref: Some(handoff.handoff_id.clone()),
+        evidence_refs: vec![format!("evidence:fabric-plan:{}", record.device_pk)],
+        blocked_reasons: vec![],
+        safe_facts: Value::Null,
+        observed_at,
+        expires_at: Some(observed_at + RECORD_TTL_MS),
+    };
+    validate_host_fabric_fulfillment_plan(&fulfillment_plan)?;
+
+    Ok(GatewayAssociationPosture {
+        substrate_association_handoff: handoff,
+        gateway_association_contribution: contribution,
+        lifecycle_plan,
+        fulfillment_plan,
+    })
+}
+
+fn gateway_fabric_ref(record: &SwarmDeviceRecord) -> String {
+    format!("fabric:gateway:{}", short_ref(&record.device_pk))
+}
+
+fn gateway_host_ref(record: &SwarmDeviceRecord) -> String {
+    format!("host:gateway:{}", short_ref(&record.device_pk))
+}
+
+fn gateway_association_ref(record: &SwarmDeviceRecord) -> String {
+    format!(
+        "association:gateway:{}:ongoing",
+        short_ref(&record.device_pk)
+    )
+}
+
+fn short_ref(value: &str) -> String {
+    let trimmed = value.trim();
+    trimmed.chars().take(12).collect()
+}
+
 fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -446,7 +649,7 @@ pub fn service_version() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{HostedServiceRecord, SwarmDeviceRecord};
+    use super::{gateway_association_posture, HostedServiceRecord, SwarmDeviceRecord};
     use serde_json::json;
 
     #[test]
@@ -491,5 +694,45 @@ mod tests {
         assert!(json.contains("\"service\":\"nvr\""));
         assert!(json.contains("\"service\":\"gateway\""));
         assert!(json.contains("\"surfaceChannel\":\"gateway.surface\""));
+    }
+
+    #[test]
+    fn gateway_record_projects_association_handoff_and_fabric_contribution() {
+        let gateway_pk = "4a29ff60c5c3837e9e20555bfeb2a046be3eb140818144628691fcf7efb1d2f1";
+        let record = SwarmDeviceRecord::new(
+            gateway_pk,
+            "identity:aux",
+            "DevGateway",
+            "gateway",
+            vec!["ws://gateway.example:7447".to_string()],
+            "ws://gateway.example:7448",
+            "linux",
+            "release",
+            "latest",
+            "",
+        );
+        let posture = gateway_association_posture(&record, 1_700_000_000).expect("posture");
+
+        assert_eq!(
+            posture.substrate_association_handoff.state,
+            constitute_protocol::FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF
+        );
+        assert_eq!(
+            posture.gateway_association_contribution.role,
+            constitute_protocol::FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION
+        );
+        assert_eq!(
+            posture.fulfillment_plan.state,
+            constitute_protocol::FABRIC_FULFILLMENT_PLAN_READY
+        );
+        assert_eq!(
+            posture.fulfillment_plan.association_handoff_ref,
+            Some(posture.substrate_association_handoff.handoff_id.clone())
+        );
+
+        let json = record.to_json();
+        assert!(json.contains("\"gatewayAssociationPosture\""));
+        assert!(json.contains("\"hostFabric.member.contribution\""));
+        assert!(json.contains("\"substrate.association.handoff\""));
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -4,15 +4,15 @@
 //! zone-scoped gateway presence signaling.
 
 use anyhow::Result;
+use constitute_fabric::{reduce_host_fabric, HostFabricReductionInput, HostFabricRoleRequirement};
 use constitute_protocol::{
-    validate_host_fabric_fulfillment_plan, validate_host_fabric_member_contribution,
-    validate_lifecycle_plan_posture, validate_substrate_association_handoff,
-    HostFabricFulfillmentPlan, HostFabricMemberContribution, LifecyclePhasePosture,
-    LifecyclePlanPosture, SubstrateAssociationHandoff, FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF,
-    FABRIC_FULFILLMENT_PLAN_READY, FABRIC_LIFECYCLE_PHASE_OBSERVE, FABRIC_LIFECYCLE_PHASE_READY,
-    FABRIC_LIFECYCLE_PHASE_RUN, FABRIC_LIFECYCLE_PHASE_RUNNING, FABRIC_LIFECYCLE_PHASE_SOURCE,
-    FABRIC_LIFECYCLE_PLAN_READY, FABRIC_MEMBER_CONTRIBUTION_RUNNING,
-    FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION, RECORD_HOST_FABRIC_FULFILLMENT_PLAN,
+    validate_host_fabric_member_contribution, validate_lifecycle_plan_posture,
+    validate_substrate_association_handoff, HostFabricFulfillmentPlan,
+    HostFabricMemberContribution, LifecyclePhasePosture, LifecyclePlanPosture,
+    SubstrateAssociationHandoff, FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF,
+    FABRIC_LIFECYCLE_PHASE_OBSERVE, FABRIC_LIFECYCLE_PHASE_READY, FABRIC_LIFECYCLE_PHASE_RUN,
+    FABRIC_LIFECYCLE_PHASE_RUNNING, FABRIC_LIFECYCLE_PHASE_SOURCE, FABRIC_LIFECYCLE_PLAN_READY,
+    FABRIC_MEMBER_CONTRIBUTION_RUNNING, FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION,
     RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION, RECORD_LIFECYCLE_PLAN_POSTURE,
     RECORD_SUBSTRATE_ASSOCIATION_HANDOFF,
 };
@@ -559,8 +559,7 @@ pub fn gateway_association_posture(
     };
     validate_lifecycle_plan_posture(&lifecycle_plan)?;
 
-    let fulfillment_plan = HostFabricFulfillmentPlan {
-        kind: Some(RECORD_HOST_FABRIC_FULFILLMENT_PLAN.to_string()),
+    let fulfillment_plan = reduce_host_fabric(HostFabricReductionInput {
         plan_id: format!(
             "fabric-plan:gateway-association:{}",
             short_ref(&record.device_pk)
@@ -568,20 +567,21 @@ pub fn gateway_association_posture(
         fabric_ref,
         host_ref,
         contract_ref: "contract:gateway-association@0.1.0".to_string(),
-        state: FABRIC_FULFILLMENT_PLAN_READY.to_string(),
-        required_role_refs: vec![format!("role:{FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION}")],
-        member_contribution_refs: vec![contribution.contribution_id.clone()],
-        missing_role_refs: vec![],
-        lifecycle_plan_refs: vec![lifecycle_plan.lifecycle_plan_id.clone()],
+        required_roles: vec![HostFabricRoleRequirement {
+            role_ref: format!("role:{FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION}"),
+            min_ready: 1,
+        }],
+        contributions: vec![contribution.clone()],
+        lifecycle_plans: vec![lifecycle_plan.clone()],
         materialization_budget_refs: vec!["materialization-budget:gateway-association".to_string()],
-        association_handoff_ref: Some(handoff.handoff_id.clone()),
+        known_missing_role_refs: vec![],
         evidence_refs: vec![format!("evidence:fabric-plan:{}", record.device_pk)],
         blocked_reasons: vec![],
-        safe_facts: Value::Null,
+        association_handoff_ref: Some(handoff.handoff_id.clone()),
         observed_at,
         expires_at: Some(observed_at + RECORD_TTL_MS),
-    };
-    validate_host_fabric_fulfillment_plan(&fulfillment_plan)?;
+    })?
+    .fulfillment_plan;
 
     Ok(GatewayAssociationPosture {
         substrate_association_handoff: handoff,

--- a/src/swarm_edge.rs
+++ b/src/swarm_edge.rs
@@ -7,10 +7,11 @@
 
 use anyhow::{anyhow, Result};
 use constitute_protocol::{
-    swarm_frame_id, validate_swarm_edge_hello, validate_swarm_edge_resume, validate_swarm_frame,
-    SwarmAck, SwarmEdgeAccept, SwarmEdgeHello, SwarmEdgeResume, SwarmFrame, SwarmFrameBody,
-    SwarmFrameKind, SwarmRecordRef, ZoneScope, CAPABILITY_PROJECTION_OBSERVE,
-    CAPABILITY_SWARM_EDGE_ATTACH, SWARM_FRAME_VERSION,
+    swarm_frame_id, validate_member_presence, validate_swarm_edge_hello,
+    validate_swarm_edge_resume, validate_swarm_frame, MemberPresence, SwarmAck, SwarmEdgeAccept,
+    SwarmEdgeHello, SwarmEdgeResume, SwarmFrame, SwarmFrameBody, SwarmFrameKind, SwarmRecordRef,
+    ZoneScope, CAPABILITY_PROJECTION_OBSERVE, CAPABILITY_SWARM_EDGE_ATTACH, RECORD_MEMBER_PRESENCE,
+    SWARM_FRAME_VERSION,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -1166,6 +1167,7 @@ impl SwarmEdgeHub {
         let mut definitions = BTreeMap::<String, Value>::new();
         let mut channels = BTreeMap::<String, Value>::new();
         let mut policies = BTreeMap::<String, Value>::new();
+        let mut membership_truth = Vec::<Value>::new();
         let mut advertisements = Vec::<Value>::new();
         let mut entries = Vec::<Value>::new();
         let mut sessions = self
@@ -1208,6 +1210,21 @@ impl SwarmEdgeHub {
             channel_refs.sort();
             channel_refs.dedup();
 
+            let presence = MemberPresence {
+                kind: Some(RECORD_MEMBER_PRESENCE.to_string()),
+                member_ref: member_ref.to_string(),
+                member_kind: session.member_kind.clone(),
+                capability_refs: capability_refs.clone(),
+                channel_refs: channel_refs.clone(),
+                issued_at: session.issued_at,
+                expires_at: session.expires_at,
+            };
+            if validate_member_presence(&presence, now).is_ok() {
+                if let Ok(value) = serde_json::to_value(&presence) {
+                    membership_truth.push(value);
+                }
+            }
+
             for capability in &capability_refs {
                 definitions.entry(capability.clone()).or_insert_with(|| {
                     json!({
@@ -1230,8 +1247,9 @@ impl SwarmEdgeHub {
                     "zoneScope": &session.zone_scope,
                     "channelRefs": channel_refs,
                     "memberSource": "attachedSessionAdvertisement",
+                    "memberPresenceRef": format!("member-presence:{}:{}", slug(member_ref), slug(&session.session_id)),
                     "authorityDomains": ["gateway", "service"],
-                    "recordBackedMembership": false,
+                    "recordBackedMembership": true,
                     "issuedAt": now,
                     "expiresAt": now.saturating_add(90_000),
                 }));
@@ -1274,8 +1292,9 @@ impl SwarmEdgeHub {
                         "promiseRefs": &promise_refs,
                         "zoneScope": &session.zone_scope,
                         "memberSource": "attachedSessionAdvertisement",
+                        "memberPresenceRef": format!("member-presence:{}:{}", slug(member_ref), slug(&session.session_id)),
                         "authorityDomains": ["gateway", "service"],
-                        "recordBackedMembership": false,
+                        "recordBackedMembership": true,
                         "priority": 10,
                     }));
                 }
@@ -1286,10 +1305,11 @@ impl SwarmEdgeHub {
             "classification": {
                 "directoryTruthSource": "attachedSessionAdvertisement",
                 "attachedHelloBoundary": "attachedSessionObservation",
-                "recordBackedMembership": false,
+                "membershipTruthSource": "edgeSessionMemberPresence",
+                "recordBackedMembership": !membership_truth.is_empty(),
                 "nostrBoundary": "bootstrapFallback",
             },
-            "membershipTruth": [],
+            "membershipTruth": membership_truth,
             "definitions": definitions.into_values().collect::<Vec<_>>(),
             "advertisements": advertisements,
             "entries": entries,

--- a/tests/swarm_edge.rs
+++ b/tests/swarm_edge.rs
@@ -799,8 +799,18 @@ fn live_directory_omits_disconnected_edge_sessions() {
         before["classification"]["directoryTruthSource"],
         "attachedSessionAdvertisement"
     );
-    assert_eq!(before["classification"]["recordBackedMembership"], false);
-    assert!(before["membershipTruth"].as_array().unwrap().is_empty());
+    assert_eq!(
+        before["classification"]["membershipTruthSource"],
+        "edgeSessionMemberPresence"
+    );
+    assert_eq!(before["classification"]["recordBackedMembership"], true);
+    assert!(before["membershipTruth"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|presence| presence["kind"] == "member.presence"
+            && presence["memberRef"] == CLI_PK
+            && presence["memberKind"] == "cli"));
     assert!(before["advertisements"]
         .as_array()
         .unwrap()
@@ -817,7 +827,11 @@ fn live_directory_omits_disconnected_edge_sessions() {
         .iter()
         .any(|ad| ad["memberRef"] == CLI_PK
             && ad["memberSource"] == "attachedSessionAdvertisement"
-            && ad["recordBackedMembership"] == false));
+            && ad["recordBackedMembership"] == true
+            && ad["memberPresenceRef"]
+                .as_str()
+                .unwrap_or("")
+                .starts_with("member-presence:")));
     assert!(before["entries"]
         .as_array()
         .unwrap()


### PR DESCRIPTION
Adds gateway association and fabric target contribution posture for route and service presence coordination.\n\nProof: local gateway/native, browser, convergence, affected, and aggregate checks passed.