### PR TITLE
Add gateway mitigation recommendation posture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=main#433f54397fdee6f5619f9de408b4a307143a0191"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Fcybersec-processor%2Ffabric-protocol-sync#eff59c897024596a34681300d1a1c54ef14ca6f1"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=main#e0db94216f0a57bf427086f225156db4625717cd"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Fcybersec-processor%2Fprotocol-posture#3724e2d5074384a30fc536fa667a5779b9959c77"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Fcybersec-processor%2Ffabric-protocol-sync#eff59c897024596a34681300d1a1c54ef14ca6f1"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=main#436dc9df1c40f74d59d75af460a0f44cd6cd61ba"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Fcybersec-processor%2Fprotocol-posture#3724e2d5074384a30fc536fa667a5779b9959c77"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=main#86bcf9988d79057ad3d567ce805ba22c7dcc094f"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ operator-gui = ["dep:eframe"]
 
 [dependencies]
 anyhow = "1"
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/cybersec-processor/fabric-protocol-sync" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/cybersec-processor/protocol-posture" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "main" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "main" }
 argon2 = "0.5"
 base64 = "0.22"
 chacha20poly1305 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ operator-gui = ["dep:eframe"]
 
 [dependencies]
 anyhow = "1"
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "main" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "main" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/cybersec-processor/fabric-protocol-sync" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/cybersec-processor/protocol-posture" }
 argon2 = "0.5"
 base64 = "0.22"
 chacha20poly1305 = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod discovery;
 pub mod keystore;
 /// Local websocket relay for browser-side clients.
 pub mod local_relay;
+/// Report-only cybersec mitigation recommendation consumer posture.
+pub mod mitigation;
 /// Nostr bootstrap/fallback key/event/signature helpers used across gateway modules.
 pub mod nostr;
 /// Platform-specific setup and default paths.

--- a/src/mitigation.rs
+++ b/src/mitigation.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use constitute_protocol::{
+    validate_cybersec_mitigation_consumer_posture, validate_cybersec_mitigation_recommendation,
+    CybersecMitigationConsumerPostureRecord, CybersecMitigationRecommendationRecord,
+    RECORD_CYBERSEC_MITIGATION_CONSUMER_POSTURE,
+};
+use serde_json::json;
+
+pub const GATEWAY_MITIGATION_CONSUMER_REF: &str = "constitute-gateway";
+
+const GATEWAY_SUPPORTED_MITIGATION_ACTIONS: &[&str] = &[
+    "observe",
+    "requestEvidence",
+    "quarantine",
+    "block",
+    "rateLimit",
+    "degrade",
+    "notify",
+];
+
+pub fn gateway_supported_mitigation_actions() -> Vec<String> {
+    GATEWAY_SUPPORTED_MITIGATION_ACTIONS
+        .iter()
+        .map(|action| (*action).to_string())
+        .collect()
+}
+
+pub fn gateway_mitigation_consumer_posture(
+    recommendation: &CybersecMitigationRecommendationRecord,
+    authority_refs: Vec<String>,
+    observed_at: u64,
+) -> Result<CybersecMitigationConsumerPostureRecord> {
+    validate_cybersec_mitigation_recommendation(recommendation)?;
+
+    let supported_actions = gateway_supported_mitigation_actions();
+    let mut blocked_reasons = Vec::new();
+    let targeted = recommendation.consumer_refs.is_empty()
+        || recommendation
+            .consumer_refs
+            .iter()
+            .any(|consumer| consumer == GATEWAY_MITIGATION_CONSUMER_REF || consumer == "gateway");
+    let supports_action = supported_actions
+        .iter()
+        .any(|action| action == &recommendation.action_kind);
+
+    let state = if recommendation
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= observed_at)
+    {
+        "expired"
+    } else if !targeted {
+        blocked_reasons.push("notTargetedToGateway".to_string());
+        "unsupported"
+    } else if !supports_action {
+        blocked_reasons.push(format!("unsupportedAction:{}", recommendation.action_kind));
+        "unsupported"
+    } else if authority_refs.is_empty() {
+        "waitingAuthority"
+    } else {
+        "actionable"
+    };
+
+    let posture = CybersecMitigationConsumerPostureRecord {
+        kind: Some(RECORD_CYBERSEC_MITIGATION_CONSUMER_POSTURE.to_string()),
+        posture_id: format!(
+            "cybersec:mitigation-consumer:gateway:{}",
+            recommendation.recommendation_id
+        ),
+        recommendation_ref: recommendation.recommendation_id.clone(),
+        finding_ref: recommendation.finding_ref.clone(),
+        processor_report_ref: recommendation.processor_report_ref.clone(),
+        consumer_ref: GATEWAY_MITIGATION_CONSUMER_REF.to_string(),
+        action_kind: recommendation.action_kind.clone(),
+        target_ref: recommendation.target_ref.clone(),
+        state: state.to_string(),
+        authority_refs,
+        supported_action_kinds: supported_actions,
+        evidence_refs: vec![recommendation.recommendation_id.clone()],
+        blocked_reasons,
+        safe_facts: json!({
+            "recommendationOnly": true,
+            "enforcementOwner": "gateway.consumer",
+            "consumerTargeted": targeted,
+            "actionSupported": supports_action
+        }),
+        observed_at,
+        expires_at: recommendation.expires_at,
+    };
+    validate_cybersec_mitigation_consumer_posture(&posture)?;
+    Ok(posture)
+}

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -2,6 +2,49 @@ use serde_json::Value;
 use std::time::Duration;
 
 #[test]
+fn gateway_reports_mitigation_recommendation_consumer_posture() {
+    let recommendation = constitute_protocol::CybersecMitigationRecommendationRecord {
+        kind: Some(constitute_protocol::RECORD_CYBERSEC_MITIGATION_RECOMMENDATION.to_string()),
+        recommendation_id: "cybersec:recommendation:media-path:request-evidence".to_string(),
+        finding_ref: "cybersec:finding:media-path".to_string(),
+        processor_report_ref: "event-fabric-report:logging.cybersec.bootstrap".to_string(),
+        recommender_ref: "processor:constitute-cybersec".to_string(),
+        action_kind: "requestEvidence".to_string(),
+        target_ref: "runtime:media-path:1".to_string(),
+        state: "recommended".to_string(),
+        authority_refs: vec!["authority:security-ops".to_string()],
+        consumer_refs: vec!["constitute-gateway".to_string()],
+        evidence_refs: vec!["cybersec:finding:media-path".to_string()],
+        safe_facts: serde_json::json!({ "recommendationOnly": true }),
+        blocked_reasons: Vec::new(),
+        issued_at: 1_700_000_000,
+        expires_at: Some(1_700_000_600),
+    };
+    let posture = constitute_gateway::mitigation::gateway_mitigation_consumer_posture(
+        &recommendation,
+        vec!["authority:gateway-mitigation".to_string()],
+        1_700_000_001,
+    )
+    .expect("posture");
+    assert_eq!(posture.state, "actionable");
+    assert_eq!(posture.recommendation_ref, recommendation.recommendation_id);
+    assert!(posture
+        .supported_action_kinds
+        .contains(&"requestEvidence".to_string()));
+
+    let mut untargeted = recommendation;
+    untargeted.consumer_refs = vec!["constitute-moderation".to_string()];
+    let posture = constitute_gateway::mitigation::gateway_mitigation_consumer_posture(
+        &untargeted,
+        vec!["authority:gateway-mitigation".to_string()],
+        1_700_000_001,
+    )
+    .expect("unsupported posture");
+    assert_eq!(posture.state, "unsupported");
+    assert_eq!(posture.blocked_reasons, vec!["notTargetedToGateway"]);
+}
+
+#[test]
 fn discovery_envelope_shape() {
     let record = constitute_gateway::discovery::SwarmDeviceRecord::new(
         "pk-test",


### PR DESCRIPTION
## Summary
Adds report-only gateway consumer posture for cybersecurity mitigation recommendations, keeping enforcement action with the gateway consumer.

## Proof
- cargo test
- root check:affected